### PR TITLE
[FEATURE] 회원 엔티티 구현

### DIFF
--- a/src/main/java/ok/cherry/global/exception/ErrorTestController.java
+++ b/src/main/java/ok/cherry/global/exception/ErrorTestController.java
@@ -97,12 +97,12 @@ public class ErrorTestController {
 	@GetMapping("/member-error/{type}")
 	public ResponseEntity<String> testMemberError(@PathVariable String type) {
 		switch (type) {
-			case "not-found":
-				throw new BusinessException(MemberError.USER_NOT_FOUND);
-			case "duplicate-email":
-				throw new BusinessException(MemberError.DUPLICATE_EMAIL);
-			case "invalid-password":
-				throw new BusinessException(MemberError.INVALID_PASSWORD);
+			case "invalid-email":
+				throw new BusinessException(MemberError.INVALID_EMAIL);
+			case "invalid-nickname":
+				throw new BusinessException(MemberError.INVALID_NICKNAME);
+			case "not-active":
+				throw new BusinessException(MemberError.NOT_ACTIVE);
 			default:
 				return ResponseEntity.ok("지원하지 않는 타입: " + type);
 		}
@@ -133,7 +133,7 @@ public class ErrorTestController {
 	 */
 	@GetMapping("/custom-message")
 	public ResponseEntity<String> testCustomMessage() {
-		throw new BusinessException(MemberError.USER_NOT_FOUND, "사용자 ID 123을 찾을 수 없습니다");
+		throw new BusinessException(MemberError.INVALID_NICKNAME, "닉네임에 특수문자를 입력할 수 없습니다");
 	}
 
 	/**

--- a/src/main/java/ok/cherry/member/domain/Email.java
+++ b/src/main/java/ok/cherry/member/domain/Email.java
@@ -1,0 +1,21 @@
+package ok.cherry.member.domain;
+
+import static ok.cherry.member.exception.MemberError.*;
+
+import java.util.regex.Pattern;
+
+import jakarta.persistence.Embeddable;
+import ok.cherry.global.exception.error.DomainException;
+
+@Embeddable
+public record Email(String address) {
+
+	private static final Pattern EMAIL_PATTERN =
+		Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$");
+
+	public Email {
+		if (!EMAIL_PATTERN.matcher(address).matches()) {
+			throw new DomainException(INVALID_EMAIL);
+		}
+	}
+}

--- a/src/main/java/ok/cherry/member/domain/Email.java
+++ b/src/main/java/ok/cherry/member/domain/Email.java
@@ -14,6 +14,10 @@ public record Email(String address) {
 		Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$");
 
 	public Email {
+		if (address == null) {
+			throw new DomainException(INVALID_EMAIL);
+		}
+
 		if (!EMAIL_PATTERN.matcher(address).matches()) {
 			throw new DomainException(INVALID_EMAIL);
 		}

--- a/src/main/java/ok/cherry/member/domain/Member.java
+++ b/src/main/java/ok/cherry/member/domain/Member.java
@@ -1,0 +1,87 @@
+package ok.cherry.member.domain;
+
+import static java.util.Objects.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ok.cherry.global.exception.error.DomainException;
+import ok.cherry.member.exception.MemberError;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private Provider provider;
+
+	private String providerId;
+
+	@Embedded
+	private Email email;
+
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	private MemberStatus status;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	private MemberDetail detail;
+
+	public static Member register(String providerId, Provider provider, String emailAddress, String nickname) {
+		validateNickname(nickname);
+
+		Member member = new Member();
+		member.email = new Email(emailAddress);
+		member.providerId = requireNonNull(providerId);
+		member.provider = requireNonNull(provider);
+		member.nickname = requireNonNull(nickname);
+		member.status = MemberStatus.ACTIVE;
+		member.detail = MemberDetail.create();
+		return member;
+	}
+
+	public void deactivate() {
+		validateIsActive();
+		this.status = MemberStatus.DEACTIVATED;
+		this.detail.deactivate();
+	}
+
+	public void updateEmail(String emailAddress) {
+		validateIsActive();
+		this.email = new Email(emailAddress);
+	}
+
+	public void updateNickname(String nickname) {
+		validateIsActive();
+		validateNickname(nickname);
+		this.nickname = nickname;
+	}
+
+	private void validateIsActive() {
+		if (status != MemberStatus.ACTIVE) {
+			throw new DomainException(MemberError.NOT_ACTIVE);
+		}
+	}
+
+	private static void validateNickname(String nickname) {
+		if (nickname.length() < 2 || nickname.length() > 10) {
+			throw new DomainException(MemberError.INVALID_NICKNAME);
+		}
+	}
+}

--- a/src/main/java/ok/cherry/member/domain/Member.java
+++ b/src/main/java/ok/cherry/member/domain/Member.java
@@ -80,7 +80,7 @@ public class Member {
 	}
 
 	private static void validateNickname(String nickname) {
-		if (nickname.length() < 2 || nickname.length() > 10) {
+		if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
 			throw new DomainException(MemberError.INVALID_NICKNAME);
 		}
 	}

--- a/src/main/java/ok/cherry/member/domain/MemberDetail.java
+++ b/src/main/java/ok/cherry/member/domain/MemberDetail.java
@@ -1,0 +1,35 @@
+package ok.cherry.member.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDetail {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private LocalDateTime registeredAt;
+
+	private LocalDateTime deactivatedAt;
+
+	static MemberDetail create() {
+		MemberDetail memberDetail = new MemberDetail();
+		memberDetail.registeredAt = LocalDateTime.now();
+		return memberDetail;
+	}
+
+	void deactivate() {
+		this.deactivatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/ok/cherry/member/domain/MemberStatus.java
+++ b/src/main/java/ok/cherry/member/domain/MemberStatus.java
@@ -1,0 +1,6 @@
+package ok.cherry.member.domain;
+
+public enum MemberStatus {
+
+	ACTIVE, DEACTIVATED
+}

--- a/src/main/java/ok/cherry/member/domain/Provider.java
+++ b/src/main/java/ok/cherry/member/domain/Provider.java
@@ -1,0 +1,6 @@
+package ok.cherry.member.domain;
+
+public enum Provider {
+
+	KAKAO
+}

--- a/src/main/java/ok/cherry/member/exception/MemberError.java
+++ b/src/main/java/ok/cherry/member/exception/MemberError.java
@@ -10,7 +10,7 @@ import ok.cherry.global.exception.error.ErrorCode;
 @RequiredArgsConstructor
 public enum MemberError implements ErrorCode {
 
-	NOT_ACTIVE("ACTIVE 상태가 아닙니다", HttpStatus.BAD_REQUEST, "M_001"),
+	NOT_ACTIVE("활성 상태가 아닙니다", HttpStatus.CONFLICT, "M_001"),
 	INVALID_NICKNAME("닉네임은 2~10글자만 가능합니다", HttpStatus.BAD_REQUEST, "M_002"),
 	INVALID_EMAIL("이메일 형식이 올바르지 않습니다", HttpStatus.BAD_REQUEST, "M_003");
 

--- a/src/main/java/ok/cherry/member/exception/MemberError.java
+++ b/src/main/java/ok/cherry/member/exception/MemberError.java
@@ -10,9 +10,9 @@ import ok.cherry.global.exception.error.ErrorCode;
 @RequiredArgsConstructor
 public enum MemberError implements ErrorCode {
 
-	USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "M_001"),
-	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT, "M_002"),
-	INVALID_PASSWORD("비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, "M_003");
+	NOT_ACTIVE("ACTIVE 상태가 아닙니다", HttpStatus.BAD_REQUEST, "M_001"),
+	INVALID_NICKNAME("닉네임은 2~10글자만 가능합니다", HttpStatus.BAD_REQUEST, "M_002"),
+	INVALID_EMAIL("이메일 형식이 올바르지 않습니다", HttpStatus.BAD_REQUEST, "M_003");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/test/java/ok/cherry/member/domain/EmailTest.java
+++ b/src/test/java/ok/cherry/member/domain/EmailTest.java
@@ -1,0 +1,35 @@
+package ok.cherry.member.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ok.cherry.global.exception.error.DomainException;
+import ok.cherry.member.exception.MemberError;
+
+class EmailTest {
+
+	@Test
+	@DisplayName("잘못된 이메일 형식으로 Email 객체 생성 시 예외가 발생한다")
+	void createEmailFail() {
+		// given
+		String wrongAddress = "wrongAddress";
+
+		// when & then
+		assertThatThrownBy(() -> new Email(wrongAddress))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_EMAIL.getMessage());
+	}
+
+	@Test
+	@DisplayName("같은 이메일 주소를 가진 Email 객체들은 동등하다")
+	void equality() {
+		// give
+		var email1 = new Email("test@test.com");
+		var email2 = new Email("test@test.com");
+
+		// when & then
+		assertThat(email1).isEqualTo(email2);
+	}
+}

--- a/src/test/java/ok/cherry/member/domain/EmailTest.java
+++ b/src/test/java/ok/cherry/member/domain/EmailTest.java
@@ -25,7 +25,7 @@ class EmailTest {
 	@Test
 	@DisplayName("같은 이메일 주소를 가진 Email 객체들은 동등하다")
 	void equality() {
-		// give
+		// given
 		var email1 = new Email("test@test.com");
 		var email2 = new Email("test@test.com");
 

--- a/src/test/java/ok/cherry/member/domain/MemberTest.java
+++ b/src/test/java/ok/cherry/member/domain/MemberTest.java
@@ -1,0 +1,180 @@
+package ok.cherry.member.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ok.cherry.global.exception.error.DomainException;
+import ok.cherry.member.exception.MemberError;
+
+class MemberTest {
+
+	@Test
+	@DisplayName("회원 등록 시 상태가 활성화되고 등록일자가 설정된다")
+	void registerMember() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when & then
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.getDetail().getRegisteredAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("잘못된 이메일 형식으로 회원 등록 시 예외가 발생한다")
+	void invalidEmail() {
+		// given
+		String invalidEmail = "wrongEmail";
+
+		// when & then
+		assertThatThrownBy(() -> Member.register("12345", Provider.KAKAO, invalidEmail, "tester"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_EMAIL.getMessage());
+	}
+
+	@Test
+	@DisplayName("2글자 미만의 문자열로 회원 등록 시 예외가 발생한다")
+	void invalidShortNickname() {
+		// given
+		String invalidNickname = "x";
+
+		// when & then
+		assertThatThrownBy(() -> Member.register("12345", Provider.KAKAO, "test@test.com", invalidNickname))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_NICKNAME.getMessage());
+	}
+
+	@Test
+	@DisplayName("10글자가 넘는 문자열로 회원 등록 시 예외가 발생한다")
+	void invalidLongNickname() {
+		// given
+		String invalidNickname = "veryLongNickname";
+
+		// when & then
+		assertThatThrownBy(() -> Member.register("12345", Provider.KAKAO, "test@test.com", invalidNickname))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_NICKNAME.getMessage());
+	}
+
+	@Test
+	@DisplayName("회원 비활성화 시 상태가 변경되고 비활성화 일자가 설정된다")
+	void deactivate() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.deactivate();
+
+		// then
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.DEACTIVATED);
+		assertThat(member.getDetail().getDeactivatedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("이미 비활성화된 회원을 다시 비활성화하려 할 때 예외가 발생한다")
+	void deactivateFail() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.deactivate();
+
+		// then
+		assertThatThrownBy(() -> member.deactivate())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.NOT_ACTIVE.getMessage());
+	}
+
+	@Test
+	@DisplayName("활성화된 회원의 이메일을 성공적으로 변경한다")
+	void updateEmail() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.updateEmail("new@email.com");
+
+		// then
+		assertThat(member.getEmail()).isEqualTo(new Email("new@email.com"));
+	}
+
+	@Test
+	@DisplayName("비활성화된 회원의 이메일 변경 시 예외가 발생한다")
+	void updateEmailFail() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.deactivate();
+
+		// then
+		assertThatThrownBy(() -> member.updateEmail("new@email.com"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.NOT_ACTIVE.getMessage());
+	}
+
+	@Test
+	@DisplayName("잘못된 이메일 형식으로 이메일 변경 시 예외가 발생한다")
+	void updateInvalidEmail() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when & then
+		assertThatThrownBy(() -> member.updateEmail("wrongEmail"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_EMAIL.getMessage());
+	}
+
+	@Test
+	@DisplayName("활성화된 회원의 닉네임을 성공적으로 변경한다")
+	void updateNickname() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.updateNickname("newName");
+
+		// then
+		assertThat(member.getNickname()).isEqualTo("newName");
+	}
+
+	@Test
+	@DisplayName("비활성화된 회원의 닉네임 변경 시 예외가 발생한다")
+	void updateNicknameFail() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when
+		member.deactivate();
+
+		// then
+		assertThatThrownBy(() -> member.updateNickname("newName"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.NOT_ACTIVE.getMessage());
+	}
+
+	@Test
+	@DisplayName("2글자 미만의 문자열로 닉네임 변경 시 예외가 발생한다")
+	void updateShortNickname() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when & then
+		assertThatThrownBy(() -> member.updateNickname("x"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_NICKNAME.getMessage());
+	}
+
+	@Test
+	@DisplayName("10글자가 넘는 문자열로 닉네임을 변경 시 예외가 발생한다")
+	void updateLongNickname() {
+		// given
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+
+		// when & then
+		assertThatThrownBy(() -> member.updateNickname("veryLongNickname"))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(MemberError.INVALID_NICKNAME.getMessage());
+	}
+}


### PR DESCRIPTION
## 관련 Issue (필수)
- close #2

## 주요 변경 사항 (필수)
- 회원 도메인 구현

## 리뷰어 참고 사항
### 회원(Member) (**Aggregate Root)**

*Entity*
**속성**
- `id`: id
- `Provider`: Oauth제공자
- `providerId`: Oauth에서 식별하는 Id
- `email`: `Email` 이메일
- `nickname`: 닉네임
- `status`: `MemberStatus` 회원 상태
- `detail`: `MemberDetail` 1:1

**행위**
- `register`: 회원 등록
- `deactivate`: 회원 탈퇴
- `updateEmail`: 회원 이메일 변경
- `updateNickname`: 회원 이름 변경

### 회원 상세(MemberDetail)
*Entity*
**속성**
- `id`: id
- `registeredAt`: 등록 일시
- `deactivatedAt`: 탈퇴 일시

**행위**
- `create`: 회원 등록. 현재 시간을 등록 시간으로 저장.
- `deactivate`: 탈퇴와 관련된 작업 수정. 탈퇴 시간 저장.

### 회원 상태(MemberStatus)
*Enum*
- `ACTIVE`: 등록 완료
- `DEACTIVATED`: 탈퇴

### 제공자(Provider)
*Enum*
- `KAKAO`: 카카오

### 이메일(Email)
*Value Object*

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 회원 도메인 도입: 회원 등록, 이메일/닉네임 업데이트, 계정 비활성화 지원
  * 이메일 값객체 추가 및 제공자 정보(Provider) 도입
* 변경사항
  * 에러 체계 정비: NOT_ACTIVE/INVALID_NICKNAME/INVALID_EMAIL로 통일, 메시지 및 상태 코드 조정
  * 닉네임(2~10자) 및 이메일 형식 검증 강화
* 테스트
  * 이메일 및 회원 도메인 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->