### PR TITLE
[CHORE] Dockerfile java 베이스 이미지 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM openjdk:21-jdk-alpine AS builder
+FROM amazoncorretto:21-alpine-jdk AS builder
 WORKDIR /app
 COPY gradlew .
 COPY gradle gradle
@@ -25,7 +25,7 @@ EXPOSE 8080
 ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-jar", "app.jar"]
 
 # Production stage
-FROM openjdk:21-jre-alpine AS production
+FROM amazoncorretto:21-alpine-jdk AS production
 
 # 타임존 설정
 RUN apk add --no-cache tzdata


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #20

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- Dockerfile의 java 베이스 이미지를 `openjdk:21-jdk-alpine` -> `amazoncorretto:21-alpine-jdk` 로 변경합니다.
- aws와의 호환성, 경량 이미지를 고려해 amazoncorretto:21-alpine-jdk 로 선택하게 되었습니다.

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
<img width="1009" height="530" alt="image" src="https://github.com/user-attachments/assets/ad723cee-0bb5-4c2c-881c-82c79090fafe" />


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 유지보수
  - 컨테이너 빌드 및 운영 단계의 기본 JDK 이미지를 Amazon Corretto 21(Alpine)으로 교체했습니다.
  - 애플리케이션 실행 방식, 노출 포트, 환경 변수, 타임존 설정, 패키징, 엔트리포인트는 기존과 동일합니다.
  - 로컬 개발 단계 구성에는 변화가 없습니다.
  - 기능 동작은 동일하며 사용자 측면 영향은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->