### PR TITLE
chore: docker 빌드 시 멀티 아치 제거 (#30)

### DIFF
--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           context: .
           target: development
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/cherry-be-dev:latest


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #30

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 멀티아치는 모든 단계가 2배로 돌아가고 arm64는 에뮬레이션이라 특히 느림 → develop 사이클 급격히 느려짐
- JAR은 플랫폼 독립이라 런타임만 아키텍처 맞춰주면 충분
- Mac 프론트 분들은 --platform=linux/amd64만 붙이면 그대로 최신 이미지 사용 가능

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우를 정리하여 멀티아키텍처 빌드 지정을 제거하고, 러너의 기본 아키텍처 이미지로만 빌드/배포하도록 변경했습니다.
  * 일반적인 x86_64 환경에서는 사용 경험에 변화가 없습니다.
  * ARM 등 특수 아키텍처 환경에서는 최신 이미지 가용성이 제한될 수 있으니, 필요 시 이전 태그 또는 별도 아키텍처 이미지를 사용해 주세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->