### PR TITLE
[CHORE] 전역 API prefix 수정

### DIFF
--- a/src/main/java/ok/cherry/auth/presentation/AuthController.java
+++ b/src/main/java/ok/cherry/auth/presentation/AuthController.java
@@ -24,7 +24,7 @@ import ok.cherry.auth.util.TempTokenGenerator;
 import ok.cherry.global.exception.error.BusinessException;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/ok/cherry/auth/presentation/KakaoLoginController.java
+++ b/src/main/java/ok/cherry/auth/presentation/KakaoLoginController.java
@@ -1,15 +1,12 @@
 package ok.cherry.auth.presentation;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ok.cherry.auth.application.AuthService;
@@ -22,36 +19,19 @@ import ok.cherry.auth.util.TempTokenGenerator;
 
 @Slf4j
 @Controller
-@RequestMapping()
+@RequestMapping("/api/v1/oauth")
 @RequiredArgsConstructor
 public class KakaoLoginController {
 
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-	
+
 	private final KakaoOAuthService kakaoOAuthService;
 	private final AuthService authService;
 	private final TempTokenGenerator tempTokenGenerator;
 	private final CookieManager cookieManager;
 
-	@Value("${kakao.client_id}")
-	private String client_id;
-
-	@Value("${kakao.redirect_uri}")
-	private String redirect_uri;
-
-	// 카카오 로그인 테스트용 페이지 컨트롤러
-	@GetMapping("/login/page")
-	public String loginPage(Model model) {
-		String location =
-			"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + client_id 
-			+ "&redirect_uri=" + redirect_uri;
-		model.addAttribute("location", location);
-
-		return "login";
-	}
-
 	// 로그인/회원가입 분기 처리
-	@GetMapping("/auth/callback")
+	@GetMapping("/callback")
 	public ResponseEntity<?> callback(
 		HttpServletResponse response,
 		@RequestParam("code") String code
@@ -59,10 +39,10 @@ public class KakaoLoginController {
 		// 1. OAuth 인증 처리
 		String accessToken = kakaoOAuthService.getAccessToken(code);
 		String providerId = kakaoOAuthService.getProviderId(accessToken);
-		
+
 		// 2. 회원가입 여부 확인
 		CheckMemberResponse checkResponse = kakaoOAuthService.checkMember(providerId);
-		
+
 		if (checkResponse.isMember()) {
 			// 3-1. 기존 회원 -> JWT 토큰 발급
 			TokenResponse tokenResponse = authService.login(providerId);
@@ -72,7 +52,7 @@ public class KakaoLoginController {
 		} else {
 			// 3-2. 신규 사용자 -> 임시 토큰 발급 (회원가입 필요)
 			String tempToken = tempTokenGenerator.generateTempToken(providerId);
-			
+
 			return ResponseEntity.status(202)
 				.body(new SignUpRequiredResponse(tempToken));
 		}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-server:
-  servlet:
-    context-path: /api/v1
-
 spring:
   profiles:
     active: local


### PR DESCRIPTION
## 관련 Issue (필수)
- close #35

## 주요 변경 사항 (필수)
- context-path 설정 제거
- 비즈니스 API 컨트롤러에 `@RequestMapping("/api/v1")`을 개별 적용 

## 리뷰어 참고 사항
기존 카카오 Oauth callback url이 `/api/v1/auth/callback`에서 `/api/v1/oauth/callback`으로 변경되었습니다

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
