### PR TITLE
[FEATURE] JWT 토큰 payload 정보 추가

### DIFF
--- a/src/main/java/ok/cherry/member/domain/Email.java
+++ b/src/main/java/ok/cherry/member/domain/Email.java
@@ -4,11 +4,15 @@ import static ok.cherry.member.exception.MemberError.*;
 
 import java.util.regex.Pattern;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import ok.cherry.global.exception.error.DomainException;
 
 @Embeddable
-public record Email(String address) {
+public record Email(
+	@Column(nullable = false, unique = true)
+	String address
+) {
 
 	private static final Pattern EMAIL_PATTERN =
 		Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$");

--- a/src/main/java/ok/cherry/member/domain/Member.java
+++ b/src/main/java/ok/cherry/member/domain/Member.java
@@ -2,6 +2,7 @@ package ok.cherry.member.domain;
 
 import static java.util.Objects.*;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -25,17 +26,21 @@ public class Member {
 	private Long id;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
 	private Provider provider;
 
+	@Column(nullable = false, unique = true, updatable = false)
 	private String providerId;
 
 	@Embedded
 	private Email email;
 
+	@Column(nullable = false, unique = true)
 	private String nickname;
 
 	@Enumerated(EnumType.STRING)
-	private MemberStatus status;
+	@Column(nullable = false)
+	private MemberStatus memberStatus;
 
 	@Embedded
 	private MemberDetail detail;
@@ -48,7 +53,7 @@ public class Member {
 		member.providerId = requireNonNull(providerId);
 		member.provider = requireNonNull(provider);
 		member.nickname = requireNonNull(nickname);
-		member.status = MemberStatus.ACTIVE;
+		member.memberStatus = MemberStatus.ACTIVE;
 		member.detail = MemberDetail.create();
 		return member;
 	}
@@ -61,7 +66,7 @@ public class Member {
 
 	public void deactivate() {
 		validateIsActive();
-		this.status = MemberStatus.DEACTIVATED;
+		this.memberStatus = MemberStatus.DEACTIVATED;
 		this.detail.deactivate();
 	}
 
@@ -77,7 +82,7 @@ public class Member {
 	}
 
 	private void validateIsActive() {
-		if (status != MemberStatus.ACTIVE) {
+		if (memberStatus != MemberStatus.ACTIVE) {
 			throw new DomainException(MemberError.NOT_ACTIVE);
 		}
 	}

--- a/src/main/java/ok/cherry/member/domain/MemberDetail.java
+++ b/src/main/java/ok/cherry/member/domain/MemberDetail.java
@@ -2,6 +2,7 @@ package ok.cherry.member.domain;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberDetail {
 
+	@Column(nullable = false)
 	private LocalDateTime registeredAt;
 
 	private LocalDateTime deactivatedAt;

--- a/src/test/java/ok/cherry/auth/jwt/TokenGeneratorTest.java
+++ b/src/test/java/ok/cherry/auth/jwt/TokenGeneratorTest.java
@@ -16,6 +16,8 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import ok.cherry.auth.exception.TokenError;
 import ok.cherry.global.exception.error.BusinessException;
+import ok.cherry.member.domain.Member;
+import ok.cherry.member.domain.Provider;
 
 class TokenGeneratorTest {
 
@@ -38,10 +40,10 @@ class TokenGeneratorTest {
 	@DisplayName("Authentication에 있는 회원 정보로 토큰을 발급한다.")
 	void generateTokens() {
 		// given
-		String providerId = "12345";
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
 
 		// when
-		var result = tokenGenerator.generateTokenDTO(providerId);
+		var result = tokenGenerator.generateTokenDTO(member);
 
 		// then
 		assertThat(result.tokenType()).isEqualTo("Bearer");
@@ -53,11 +55,11 @@ class TokenGeneratorTest {
 	@DisplayName("유효한 refreshToken 으로 accessToken을 재발급한다.")
 	void refreshAccessToken() {
 		// given
-		String providerId = "12345";
-		var tokenResponse = tokenGenerator.generateTokenDTO(providerId);
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
+		var tokenResponse = tokenGenerator.generateTokenDTO(member);
 
 		// when
-		var result = tokenGenerator.reissueAccessToken(tokenResponse.refreshToken());
+		var result = tokenGenerator.reissueAccessToken(tokenResponse.refreshToken(), member);
 
 		// then
 		tokenValidator.validateToken(result.accessToken());
@@ -67,16 +69,16 @@ class TokenGeneratorTest {
 	@DisplayName("만료된 refreshToken 으로 accessToken 재발급을 시도하면 예외가 발생한다.")
 	void shouldThrowExceptionWhenReissuingAccessTokenWithInvalidRefreshToken() {
 		// given
-		String providerId = "12345";
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
 		String invalidRefreshToken = Jwts.builder()
-			.setSubject(providerId)
+			.setSubject(member.getProviderId())
 			.claim("isRefreshToken", true)
 			.setExpiration(new Date(System.currentTimeMillis() - 1000))
 			.signWith(testKey, SignatureAlgorithm.HS512)
 			.compact();
 
 		// when & then
-		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(invalidRefreshToken))
+		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(invalidRefreshToken, member))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(TokenError.INVALID_REFRESH_TOKEN.getMessage());
 	}
@@ -85,15 +87,15 @@ class TokenGeneratorTest {
 	@DisplayName("isRefreshToken 클레임이 없는 refreshToken 으로 accessToken 재발급을 시도하면 예외가 발생한다.")
 	void shouldThrowExceptionWhenReissuingAccessTokenWithoutRefreshTokenClaim() {
 		// given
-		String providerId = "12345";
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
 		String tokenWithoutClaim = Jwts.builder()
-			.setSubject(providerId)
+			.setSubject(member.getProviderId())
 			.setExpiration(new Date(System.currentTimeMillis() + 1000 * 60))
 			.signWith(testKey, SignatureAlgorithm.HS512)
 			.compact();
 
 		// when & then
-		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(tokenWithoutClaim))
+		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(tokenWithoutClaim, member))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(TokenError.INVALID_REFRESH_TOKEN.getMessage());
 	}
@@ -102,16 +104,16 @@ class TokenGeneratorTest {
 	@DisplayName("isRefreshToken 클레임이 false인 refreshToken 으로 accessToken 재발급을 시도하면 예외가 발생한다.")
 	void shouldThrowExceptionWhenReissuingAccessTokenWithFalseRefreshTokenClaim() {
 		// given
-		String providerId = "12345";
+		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
 		String tokenWithFalseClaim = Jwts.builder()
-			.setSubject(providerId)
+			.setSubject(member.getProviderId())
 			.claim("isRefreshToken", false)
 			.setExpiration(new Date(System.currentTimeMillis() + 1000 * 60))
 			.signWith(testKey, SignatureAlgorithm.HS512)
 			.compact();
 
 		// when & then
-		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(tokenWithFalseClaim))
+		assertThatThrownBy(() -> tokenGenerator.reissueAccessToken(tokenWithFalseClaim, member))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(TokenError.INVALID_REFRESH_TOKEN.getMessage());
 	}

--- a/src/test/java/ok/cherry/member/domain/MemberTest.java
+++ b/src/test/java/ok/cherry/member/domain/MemberTest.java
@@ -17,7 +17,7 @@ class MemberTest {
 		Member member = Member.register("12345", Provider.KAKAO, "test@test.com", "tester");
 
 		// when & then
-		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
 		assertThat(member.getDetail().getRegisteredAt()).isNotNull();
 	}
 
@@ -67,7 +67,7 @@ class MemberTest {
 		member.deactivate();
 
 		// then
-		assertThat(member.getStatus()).isEqualTo(MemberStatus.DEACTIVATED);
+		assertThat(member.getMemberStatus()).isEqualTo(MemberStatus.DEACTIVATED);
 		assertThat(member.getDetail().getDeactivatedAt()).isNotNull();
 	}
 


### PR DESCRIPTION
## 관련 Issue (필수)
- close #52 

## 주요 변경 사항 (필수)
- accessToken payload에 회원 닉네임, 이메일을 추가
- MemberEntity에 제약 조건 추가

## 리뷰어 참고 사항
accessToken은 아래와 같이 전송될 예정이며, 여기서 sub 값이 providerId에 해당합니다.
providerId 기반 조회가 많을 것으로 예상되어 인덱스를 추가하려 했는데
기존 Member 엔티티에 제약조건이 없어서 이번에 함께 추가했습니다.
<img width="548" height="217" alt="image" src="https://github.com/user-attachments/assets/b0a05635-0f3d-445b-bb2f-5390edbd96fd" />


## 추가 정보
`@Column(nullable = false, unique = true)`와 같이 제약조건을 설정하면, JPA가 자동으로 UNIQUE 제약조건을 생성하고 DBMS가 이를 위해 유니크 인덱스를 생성해줍니다.
저도 이번에 새롭게 알게 되어 공유드립니다!

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 액세스 토큰에 닉네임과 이메일 클레임을 포함해 연동 서비스에서의 사용자 식별을 개선했습니다.
  - 가입/프로필 정보 검증을 강화했습니다: 이메일·닉네임 고유 및 필수, 소셜 식별자 고유/불변, 등록 일시 필수.
- Bug Fixes
  - 존재하지 않는 사용자로 로그인 또는 토큰 재발급을 시도할 때 더 정확한 오류를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->