### PR TITLE
[REFACTOR] 주문번호, 배송번호 생성 로직 분리

### DIFF
--- a/src/main/java/ok/cherry/rental/domain/Rental.java
+++ b/src/main/java/ok/cherry/rental/domain/Rental.java
@@ -21,8 +21,10 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ok.cherry.global.exception.error.DomainException;
 import ok.cherry.member.domain.Member;
 import ok.cherry.rental.domain.status.RentalStatus;
+import ok.cherry.rental.exception.RentalError;
 
 @Entity
 @Getter
@@ -60,6 +62,8 @@ public class Rental {
 		LocalDateTime startAt,
 		LocalDateTime endAt
 	) {
+		validateRentalNumber(rentalNumber);
+
 		Rental rental = new Rental();
 		rental.member = member;
 		rental.totalPrice = calculateTotalPrice(items);
@@ -79,5 +83,11 @@ public class Rental {
 		return items.stream()
 			.map(RentalItem::getPrice)
 			.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	private static void validateRentalNumber(String rentalNumber) {
+		if (rentalNumber == null || !rentalNumber.matches("^CH-\\d{20}$")) {
+			throw new DomainException(RentalError.INVALID_RENTAL_NUMBER);
+		}
 	}
 }

--- a/src/main/java/ok/cherry/rental/domain/Rental.java
+++ b/src/main/java/ok/cherry/rental/domain/Rental.java
@@ -40,6 +40,9 @@ public class Rental {
 	@Column(nullable = false)
 	private BigDecimal totalPrice;
 
+	@Column(nullable = false, unique = true)
+	private String rentalNumber;
+
 	@OneToMany(mappedBy = "rental", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<RentalItem> rentalItems = new ArrayList<>();
 
@@ -50,11 +53,18 @@ public class Rental {
 	@Embedded
 	private RentalDetail detail;
 
-	public static Rental create(Member member, List<RentalItem> items, LocalDateTime startAt, LocalDateTime endAt) {
+	public static Rental create(
+		Member member,
+		List<RentalItem> items,
+		String rentalNumber,
+		LocalDateTime startAt,
+		LocalDateTime endAt
+	) {
 		Rental rental = new Rental();
 		rental.member = member;
 		rental.totalPrice = calculateTotalPrice(items);
 		rental.detail = RentalDetail.create(startAt, endAt);
+		rental.rentalNumber = rentalNumber;
 		rental.rentalStatus = RentalStatus.PENDING;
 
 		items.forEach(item -> {

--- a/src/main/java/ok/cherry/rental/exception/RentalError.java
+++ b/src/main/java/ok/cherry/rental/exception/RentalError.java
@@ -1,0 +1,18 @@
+package ok.cherry.rental.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ok.cherry.global.exception.error.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum RentalError implements ErrorCode {
+
+	INVALID_RENTAL_NUMBER("대여 번호가 유효하지 않습니다", HttpStatus.BAD_REQUEST, "R_001");
+
+	private final String message;
+	private final HttpStatus status;
+	private final String code;
+}

--- a/src/main/java/ok/cherry/rental/util/RentalNumberGenerator.java
+++ b/src/main/java/ok/cherry/rental/util/RentalNumberGenerator.java
@@ -14,6 +14,6 @@ public class RentalNumberGenerator {
 		int randomNumber = random.nextInt(100000000);
 		String numericSuffix = String.format("%08d", randomNumber);
 
-		return "CH" + dateTime + numericSuffix;
+		return "CH-" + dateTime + numericSuffix;
 	}
 }

--- a/src/main/java/ok/cherry/rental/util/RentalNumberGenerator.java
+++ b/src/main/java/ok/cherry/rental/util/RentalNumberGenerator.java
@@ -1,0 +1,19 @@
+package ok.cherry.rental.util;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class RentalNumberGenerator {
+
+	private static final SecureRandom random = new SecureRandom();
+
+	public static String generate() {
+		String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
+
+		int randomNumber = random.nextInt(100000000);
+		String numericSuffix = String.format("%08d", randomNumber);
+
+		return "CH" + dateTime + numericSuffix;
+	}
+}

--- a/src/main/java/ok/cherry/shipping/domain/Shipping.java
+++ b/src/main/java/ok/cherry/shipping/domain/Shipping.java
@@ -1,9 +1,5 @@
 package ok.cherry.shipping.domain;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Random;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -40,7 +36,7 @@ public class Shipping {
 	@JoinColumn(name = "rental_id", nullable = false)
 	private Rental rental;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String trackingNumber;
 
 	@Enumerated(EnumType.STRING)
@@ -63,6 +59,7 @@ public class Shipping {
 		Direction direction,
 		String receiver,
 		String phoneNumber,
+		String trackingNumber,
 		Address address
 	) {
 		Shipping shipping = new Shipping();
@@ -70,18 +67,9 @@ public class Shipping {
 		shipping.rental = rental;
 		shipping.direction = direction;
 		shipping.shippingInfo = ShippingInfo.create(receiver, phoneNumber, address);
-		shipping.trackingNumber = generateTrackingNumber();
+		shipping.trackingNumber = trackingNumber;
 		shipping.status = ShippingStatus.PENDING;
 		shipping.detail = ShippingDetail.create();
 		return shipping;
-	}
-
-	private static String generateTrackingNumber() {
-		String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
-
-		int randomNumber = new Random().nextInt(100000000);
-		String numericSuffix = String.format("%08d", randomNumber);
-
-		return dateTime + numericSuffix;
 	}
 }

--- a/src/main/java/ok/cherry/shipping/domain/Shipping.java
+++ b/src/main/java/ok/cherry/shipping/domain/Shipping.java
@@ -14,10 +14,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ok.cherry.global.exception.error.DomainException;
 import ok.cherry.member.domain.Member;
 import ok.cherry.rental.domain.Rental;
 import ok.cherry.shipping.domain.status.ShippingStatus;
 import ok.cherry.shipping.domain.type.Direction;
+import ok.cherry.shipping.exception.ShippingError;
 
 @Entity
 @Getter
@@ -62,6 +64,8 @@ public class Shipping {
 		String trackingNumber,
 		Address address
 	) {
+		validateTrackingNumber(trackingNumber);
+
 		Shipping shipping = new Shipping();
 		shipping.member = member;
 		shipping.rental = rental;
@@ -71,5 +75,11 @@ public class Shipping {
 		shipping.status = ShippingStatus.PENDING;
 		shipping.detail = ShippingDetail.create();
 		return shipping;
+	}
+
+	private static void validateTrackingNumber(String trackingNumber) {
+		if (trackingNumber == null || !trackingNumber.matches("^\\d{20}$")) {
+			throw new DomainException(ShippingError.INVALID_TRACKING_NUMBER);
+		}
 	}
 }

--- a/src/main/java/ok/cherry/shipping/exception/ShippingError.java
+++ b/src/main/java/ok/cherry/shipping/exception/ShippingError.java
@@ -1,0 +1,18 @@
+package ok.cherry.shipping.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ok.cherry.global.exception.error.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShippingError implements ErrorCode {
+
+	INVALID_TRACKING_NUMBER("배송 번호가 유효하지 않습니다", HttpStatus.BAD_REQUEST, "S_001");
+
+	private final String message;
+	private final HttpStatus status;
+	private final String code;
+}

--- a/src/main/java/ok/cherry/shipping/util/TrackingNumberGenerator.java
+++ b/src/main/java/ok/cherry/shipping/util/TrackingNumberGenerator.java
@@ -1,0 +1,19 @@
+package ok.cherry.shipping.util;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TrackingNumberGenerator {
+
+	private static final SecureRandom random = new SecureRandom();
+
+	public static String generate() {
+		String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
+
+		int randomNumber = random.nextInt(100000000);
+		String numericSuffix = String.format("%08d", randomNumber);
+
+		return dateTime + numericSuffix;
+	}
+}

--- a/src/test/java/ok/cherry/rental/RentalBuilder.java
+++ b/src/test/java/ok/cherry/rental/RentalBuilder.java
@@ -15,6 +15,7 @@ public class RentalBuilder {
 
 	public Member member = MemberBuilder.create();
 	public List<RentalItem> rentalItems = List.of(RentalItemBuilder.create());
+	public String rentalNumber = "CH-25090213363012345678";
 	public LocalDateTime startAt = LocalDateTime.now();
 	public LocalDateTime endAt = LocalDateTime.now().plusDays(7);
 
@@ -27,7 +28,7 @@ public class RentalBuilder {
 	}
 
 	public Rental build() {
-		return Rental.create(member, rentalItems, startAt, endAt);
+		return Rental.create(member, rentalItems, rentalNumber, startAt, endAt);
 	}
 
 	public RentalBuilder withMember(Member member) {
@@ -37,6 +38,11 @@ public class RentalBuilder {
 
 	public RentalBuilder withRentalItems(List<RentalItem> rentalItems) {
 		this.rentalItems = rentalItems;
+		return this;
+	}
+
+	public RentalBuilder withRentalNumber(String rentalNumber) {
+		this.rentalNumber = rentalNumber;
 		return this;
 	}
 

--- a/src/test/java/ok/cherry/rental/domain/RentalTest.java
+++ b/src/test/java/ok/cherry/rental/domain/RentalTest.java
@@ -9,10 +9,12 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import ok.cherry.global.exception.error.DomainException;
 import ok.cherry.member.MemberBuilder;
 import ok.cherry.member.domain.Member;
 import ok.cherry.rental.RentalBuilder;
 import ok.cherry.rental.RentalItemBuilder;
+import ok.cherry.rental.exception.RentalError;
 
 class RentalTest {
 
@@ -65,5 +67,17 @@ class RentalTest {
 		assertThat(rental.getRentalItems()).hasSize(2);
 		assertThat(rental.getRentalItems())
 			.allMatch(rentalItem -> rentalItem.getRental() == rental);
+	}
+
+	@Test
+	@DisplayName("대여 생성 시 대여번호가 형식이 다르면 예외가 발생한다")
+	void createShippingWithTrackingNumber() {
+		// given
+		String wrongRentalNumber = "wrong_rental_number";
+
+		// when & then
+		assertThatThrownBy(() -> RentalBuilder.builder().withRentalNumber(wrongRentalNumber).build())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(RentalError.INVALID_RENTAL_NUMBER.getMessage());
 	}
 }

--- a/src/test/java/ok/cherry/rental/domain/RentalTest.java
+++ b/src/test/java/ok/cherry/rental/domain/RentalTest.java
@@ -22,11 +22,12 @@ class RentalTest {
 		// given
 		Member member = MemberBuilder.create();
 		RentalItem rentalItem = RentalItemBuilder.create();
+		String rentalNumber = "CH-25090213363012345678";
 		LocalDateTime startAt = LocalDateTime.now();
 		LocalDateTime endAt = LocalDateTime.now().plusDays(7);
 
 		// when
-		Rental rental = Rental.create(member, List.of(rentalItem), startAt, endAt);
+		Rental rental = Rental.create(member, List.of(rentalItem), rentalNumber, startAt, endAt);
 
 		// then
 		assertThat(rental.getDetail().getCreatedAt()).isNotNull();

--- a/src/test/java/ok/cherry/shipping/ShippingBuilder.java
+++ b/src/test/java/ok/cherry/shipping/ShippingBuilder.java
@@ -15,6 +15,7 @@ public class ShippingBuilder {
 	public Direction direction = Direction.OUTBOUND;
 	public String receiver = "tester";
 	public String phoneNumber = "010-1234-5678";
+	public String trackingNumber = "25090213363012345678";
 	public Address address = new Address("12345", "postAddress", "detailAddress");
 
 	public static Shipping create() {
@@ -26,7 +27,7 @@ public class ShippingBuilder {
 	}
 
 	public Shipping build() {
-		return Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, address);
+		return Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, trackingNumber, address);
 	}
 
 	public ShippingBuilder withRental(Rental rental) {
@@ -46,6 +47,11 @@ public class ShippingBuilder {
 
 	public ShippingBuilder withPhoneNumber(String phoneNumber) {
 		this.phoneNumber = phoneNumber;
+		return this;
+	}
+
+	public ShippingBuilder withTrackingNumber(String trackingNumber) {
+		this.trackingNumber = trackingNumber;
 		return this;
 	}
 

--- a/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
+++ b/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import ok.cherry.global.exception.error.DomainException;
 import ok.cherry.rental.RentalBuilder;
 import ok.cherry.rental.domain.Rental;
+import ok.cherry.shipping.ShippingBuilder;
 import ok.cherry.shipping.domain.status.ShippingStatus;
 import ok.cherry.shipping.domain.type.Direction;
+import ok.cherry.shipping.exception.ShippingError;
 
 class ShippingTest {
 
@@ -93,29 +96,14 @@ class ShippingTest {
 	}
 
 	@Test
-	@DisplayName("배송 생성 시 배송번호가 자동으로 생성된다")
+	@DisplayName("배송 생성 시 배송번호가 형식이 다르면 예외가 발생한다")
 	void createShippingWithTrackingNumber() {
 		// given
-		Rental rental = RentalBuilder.create();
-		Direction direction = Direction.OUTBOUND;
-		String receiver = "tester";
-		String phoneNumber = "010-1234-5678";
-		String trackingNumber = "25090213363012345678";
-		Address address = new Address("12345", "postAddress", "detailAddress");
+		String trackingNumber = "wrong_tracking_number";
 
-		// when
-		Shipping shipping = Shipping.create(
-			rental.getMember(),
-			rental,
-			direction,
-			receiver,
-			phoneNumber,
-			trackingNumber,
-			address
-		);
-
-		// then
-		assertThat(shipping.getTrackingNumber()).isNotNull();
-		assertThat(shipping.getTrackingNumber()).hasSize(20);
+		// when & then
+		assertThatThrownBy(() -> ShippingBuilder.builder().withTrackingNumber(trackingNumber).build())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(ShippingError.INVALID_TRACKING_NUMBER.getMessage());
 	}
 }

--- a/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
+++ b/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
@@ -20,10 +20,19 @@ class ShippingTest {
 		Direction direction = Direction.OUTBOUND;
 		String receiver = "tester";
 		String phoneNumber = "010-1234-5678";
+		String trackingNumber = "25090213363012345678";
 		Address address = new Address("12345", "postAddress", "detailAddress");
 
 		// when
-		Shipping shipping = Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, address);
+		Shipping shipping = Shipping.create(
+			rental.getMember(),
+			rental,
+			direction,
+			receiver,
+			phoneNumber,
+			trackingNumber,
+			address
+		);
 
 		// then
 		assertThat(shipping.getDetail().getCreatedAt()).isNotNull();
@@ -37,10 +46,19 @@ class ShippingTest {
 		Direction direction = Direction.OUTBOUND;
 		String receiver = "tester";
 		String phoneNumber = "010-1234-5678";
+		String trackingNumber = "25090213363012345678";
 		Address address = new Address("12345", "postAddress", "detailAddress");
 
 		// when
-		Shipping shipping = Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, address);
+		Shipping shipping = Shipping.create(
+			rental.getMember(),
+			rental,
+			direction,
+			receiver,
+			phoneNumber,
+			trackingNumber,
+			address
+		);
 
 		// then
 		assertThat(shipping.getStatus()).isEqualTo(ShippingStatus.PENDING);
@@ -54,10 +72,19 @@ class ShippingTest {
 		Direction direction = Direction.OUTBOUND;
 		String receiver = "tester";
 		String phoneNumber = "010-1234-5678";
+		String trackingNumber = "25090213363012345678";
 		Address address = new Address("12345", "postAddress", "detailAddress");
 
 		// when
-		Shipping shipping = Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, address);
+		Shipping shipping = Shipping.create(
+			rental.getMember(),
+			rental,
+			direction,
+			receiver,
+			phoneNumber,
+			trackingNumber,
+			address
+		);
 
 		// then
 		assertThat(shipping.getShippingInfo().getReceiver()).isEqualTo("tester");
@@ -73,10 +100,19 @@ class ShippingTest {
 		Direction direction = Direction.OUTBOUND;
 		String receiver = "tester";
 		String phoneNumber = "010-1234-5678";
+		String trackingNumber = "25090213363012345678";
 		Address address = new Address("12345", "postAddress", "detailAddress");
 
 		// when
-		Shipping shipping = Shipping.create(rental.getMember(), rental, direction, receiver, phoneNumber, address);
+		Shipping shipping = Shipping.create(
+			rental.getMember(),
+			rental,
+			direction,
+			receiver,
+			phoneNumber,
+			trackingNumber,
+			address
+		);
 
 		// then
 		assertThat(shipping.getTrackingNumber()).isNotNull();


### PR DESCRIPTION
## 관련 Issue (필수)
- close #59 

## 주요 변경 사항 (필수)
- 대여 번호 생성 로직 추가
- 배송 번호 생성 로직 추가

## 리뷰어 참고 사항
기존 도메인 내부에서 생성되는 로직을 외부로 분리하였습니다. Service계층에서 Rental, Shipping 번호를 생성해서 도메인 객체에 주입하는 방식으로 사용하시면 될 것 같습니다!

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 대여에 고유한 대여번호(rentalNumber) 필드가 추가되어 생성 시 필수로 입력·표시됩니다.
  - 배송에 고유한 운송장번호(trackingNumber) 필드가 추가되어 생성 시 필수로 입력·표시됩니다.
  - 번호 생성 유틸리티가 도입되어 표준 형식의 식별자를 생성할 수 있습니다.
- 버그 수정/검증
  - 대여번호와 운송장번호 형식 검증이 추가되어 유효하지 않은 입력은 오류로 처리됩니다.
- 테스트
  - 신규 번호 체계와 검증을 반영하도록 테스트와 빌더를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->