### PR TITLE
[CI/CD] Prod 환경 이미지 빌드 시 target 지정 추가

### DIFF
--- a/.github/workflows/deploy_cherry_on_main_with_k8s.yml
+++ b/.github/workflows/deploy_cherry_on_main_with_k8s.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # 전체 레포를 루트 기준으로 체크아웃
       - name: checkout github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: install kubectl
         uses: azure/setup-kubectl@v3
@@ -21,7 +21,7 @@ jobs:
 
       # AWS CLI 설치 및 configure
       - name: configure aws
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
@@ -33,18 +33,22 @@ jobs:
 
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: build and push docker image to ecr
-        env:
-          REGISTRY: 134125630963.dkr.ecr.ap-northeast-2.amazonaws.com
-          REPOSITORY: cherry-backend
-          IMAGE_TAG: latest
-        run: |
-          docker build \
-          -t $REGISTRY/$REPOSITORY:$IMAGE_TAG \
-          -f ./Dockerfile .
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image to ECR
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: production
+          push: true
+          tags: |
+            134125630963.dkr.ecr.ap-northeast-2.amazonaws.com/cherry-backend:latest
+            134125630963.dkr.ecr.ap-northeast-2.amazonaws.com/cherry-backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: eks kubectl apply
         run: |


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #66

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
**1. Docker 빌드 타겟 명시적 지정**
- docker build 명령에 `--target production` 옵션 추가
- multi-stage Dockerfile에서 의도한 환경별 stage를 명확하게 지정

**2. 빌드 캐시 최적화 도입**
- `docker/build-push-action@v5` 액션으로 변경
- `GitHub Actions 캐시 (type=gha)` 활용하여 빌드 시간 단축
- `docker/setup-buildx-action@v3` 추가로 고급 빌드 기능 지원

**3. 이미지 태깅 전략 개선**
- latest 태그와 함께 `github.sha` 태그 추가
- 배포 이력 추적 및 롤백 시 버전 식별 용이

**4. GitHub Actions 버전 업데이트**
- actions/checkout@v4, aws-actions/configure-aws-credentials@v4 등 최신 버전 적용
- 보안 패치 및 성능 개선 반영

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
빌드 캐시 동작
- 아래 명령줄 Docker 빌드 캐시 동작 ->  GitHub Actions의 built-in 캐시 스토리지를 사용
  - https://github.com/docker/build-push-action
  ```
  yamlcache-from: type=gha
  cache-to: type=gha,mode=max
  ```
- Docker 레이어 캐시가 GitHub Actions 스토리지에 저장됨
- 의존성 다운로드(./gradlew dependencies) 결과가 캐시되어 소스 코드만 변경 시 빌드 시간 대폭 단축
- 캐시는 repository별로 격리되며 최대 10GB까지 무료 사용 가능
  - https://docs.github.com/ko/actions/reference/workflows-and-actions/dependency-caching

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
