### PR TITLE
[FEATURE] 이메일, 닉네임 중복 검증 api 구현

### DIFF
--- a/src/main/java/ok/cherry/global/swagger/Member/MemberControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/Member/MemberControllerDoc.java
@@ -1,0 +1,33 @@
+package ok.cherry.global.swagger.Member;
+
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ok.cherry.member.application.dto.request.EmailDuplicationRequest;
+import ok.cherry.member.application.dto.request.NicknameDuplicationRequest;
+
+@Tag(name = "Members", description = "👤 회원 API - 회원 정보 조회, 수정, 탈퇴, 관리 API")
+public interface MemberControllerDoc {
+
+	@Operation(method = "POST", summary = "회원 이메일 중복 검증", description = "회원가입 시 입력한 이메일의 중복을 검증합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200",
+			description = "가입 가능한 이메일"),
+		@ApiResponse(responseCode = "409",
+			description = "이미 존재하는 이메일")
+	})
+	ResponseEntity<Void> verifyEmailDuplication(EmailDuplicationRequest request);
+
+	@Operation(method = "POST", summary = "회원 닉네임 중복 검증", description = "회원가입 시 입력한 닉네임의 중복을 검증합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200",
+			description = "가입 가능한 닉네임"),
+		@ApiResponse(responseCode = "409",
+			description = "이미 존재하는 닉네임")
+	})
+	ResponseEntity<Void> verifyNicknameDuplication(NicknameDuplicationRequest request);
+}
+

--- a/src/main/java/ok/cherry/global/swagger/member/MemberControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/member/MemberControllerDoc.java
@@ -1,4 +1,4 @@
-package ok.cherry.global.swagger.Member;
+package ok.cherry.global.swagger.member;
 
 import org.springframework.http.ResponseEntity;
 

--- a/src/main/java/ok/cherry/member/application/MemberService.java
+++ b/src/main/java/ok/cherry/member/application/MemberService.java
@@ -1,0 +1,23 @@
+package ok.cherry.member.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import ok.cherry.member.infrastructure.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public boolean verifyEmailDuplication(String emailAddress) {
+		return memberRepository.existsByEmailAddress(emailAddress);
+	}
+
+	public boolean verifyNicknameDuplication(String nickname) {
+		return memberRepository.existsByNickname(nickname);
+	}
+}

--- a/src/main/java/ok/cherry/member/application/dto/request/EmailDuplicationRequest.java
+++ b/src/main/java/ok/cherry/member/application/dto/request/EmailDuplicationRequest.java
@@ -1,0 +1,15 @@
+package ok.cherry.member.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 중복 검증 요청 DTO")
+public record EmailDuplicationRequest(
+
+    @Schema(description = "이메일", example = "user@example.com")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    String emailAddress
+) {
+}

--- a/src/main/java/ok/cherry/member/application/dto/request/NicknameDuplicationRequest.java
+++ b/src/main/java/ok/cherry/member/application/dto/request/NicknameDuplicationRequest.java
@@ -1,0 +1,16 @@
+package ok.cherry.member.application.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "닉네임 중복 검증 요청 DTO")
+public record NicknameDuplicationRequest(
+
+    @Schema(description = "닉네임", example = "nickname")
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Length(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+    String nickname
+) {
+}

--- a/src/main/java/ok/cherry/member/presentation/MemberController.java
+++ b/src/main/java/ok/cherry/member/presentation/MemberController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import ok.cherry.global.swagger.Member.MemberControllerDoc;
+import ok.cherry.global.swagger.member.MemberControllerDoc;
 import ok.cherry.member.application.MemberService;
 import ok.cherry.member.application.dto.request.EmailDuplicationRequest;
 import ok.cherry.member.application.dto.request.NicknameDuplicationRequest;

--- a/src/main/java/ok/cherry/member/presentation/MemberController.java
+++ b/src/main/java/ok/cherry/member/presentation/MemberController.java
@@ -1,0 +1,39 @@
+package ok.cherry.member.presentation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import ok.cherry.global.swagger.Member.MemberControllerDoc;
+import ok.cherry.member.application.MemberService;
+import ok.cherry.member.application.dto.request.EmailDuplicationRequest;
+import ok.cherry.member.application.dto.request.NicknameDuplicationRequest;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController implements MemberControllerDoc {
+
+	private final MemberService memberService;
+
+	@PostMapping("/verify/email")
+	public ResponseEntity<Void> verifyEmailDuplication(@Valid @RequestBody EmailDuplicationRequest request) {
+		if (memberService.verifyEmailDuplication(request.emailAddress())) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).build();
+		}
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/verify/nickname")
+	public ResponseEntity<Void> verifyNicknameDuplication(@Valid @RequestBody NicknameDuplicationRequest request) {
+		if (memberService.verifyNicknameDuplication(request.nickname())) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).build();
+		}
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,16 +2,16 @@
 
 -- Member 데이터 (기존 데이터가 없다면)
 -- Member 데이터 (Email 임베디드 타입 고려)
-INSERT INTO member (id, provider, provider_id, address, nickname, member_status, registered_at, deactivated_at)
+INSERT INTO member (id, provider, provider_id, email, nickname, member_status, registered_at, deactivated_at)
 VALUES (1, 'KAKAO', 'kakao_12345', 'test1@test.com', 'tester1', 'ACTIVE', NOW(), NULL),
        (2, 'KAKAO', 'kakao_67890', 'test2@test.com', 'tester2', 'ACTIVE', NOW(), NULL),
        (3, 'KAKAO', 'kakao_11111', 'test3@test.com', 'tester3', 'ACTIVE', NOW(), NULL);
 
 -- Product 데이터 (기존 데이터가 없다면)
-INSERT INTO product (id, name, brand, daily_rental_price, launched_at, registered_at)
-VALUES (1, 'SONY WH-1000XM6', 'SONY', 10000.00, '2025-01-01 00:00:00', NOW()),
-       (2, 'BOSE QuietComfort Ultra', 'BOSE', 12000.00, '2025-01-01 00:00:00', NOW()),
-       (3, 'Apple AirPods Max', 'APPLE', 15000.00, '2025-01-01 00:00:00', NOW());
+INSERT INTO product (id, name, brand, daily_rental_price, launched_at, registered_at, thumbnail_url)
+VALUES (1, 'SONY WH-1000XM6', 'SONY', 10000.00, '2025-01-01 00:00:00', NOW(), 'thumbnail_url'),
+       (2, 'BOSE QuietComfort Ultra', 'BOSE', 12000.00, '2025-01-01 00:00:00', NOW(), 'thumbnail_url'),
+       (3, 'Apple AirPods Max', 'APPLE', 15000.00, '2025-01-01 00:00:00', NOW(), 'thumbnail_url');
 
 -- Product 색상 데이터
 INSERT INTO product_colors (product_id, colors)

--- a/src/test/java/ok/cherry/member/application/MemberServiceTest.java
+++ b/src/test/java/ok/cherry/member/application/MemberServiceTest.java
@@ -1,0 +1,80 @@
+package ok.cherry.member.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import ok.cherry.member.MemberBuilder;
+import ok.cherry.member.domain.Member;
+import ok.cherry.member.infrastructure.MemberRepository;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+	@Autowired
+	MemberService memberService;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("중복된 이메일이면 true를 반환한다")
+	void checkEmailDuplication_true() {
+		// given
+		Member member = MemberBuilder.create();
+		memberRepository.save(member);
+
+		// when
+		boolean result = memberService.verifyEmailDuplication("test@test.com");
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("중복되지 않은 이메일이면 false를 반환한다")
+	void checkEmailDuplication_false() {
+		// given
+		Member member = MemberBuilder.create();
+		memberRepository.save(member);
+
+		// when
+		boolean result = memberService.verifyEmailDuplication("new@test.com");
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("중복된 닉네임이면 true를 반환한다")
+	void checkNicknameDuplication_true() {
+		// given
+		Member member = MemberBuilder.create();
+		memberRepository.save(member);
+
+		// when
+		boolean result = memberService.verifyNicknameDuplication("tester");
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("중복되지 않은 닉네임이면 false를 반환한다")
+	void checkNicknameDuplication_false() {
+		// given
+		Member member = MemberBuilder.create();
+		memberRepository.save(member);
+
+		// when
+		boolean result = memberService.verifyNicknameDuplication("new");
+
+		// then
+		assertThat(result).isFalse();
+	}
+}


### PR DESCRIPTION
## 관련 Issue (필수)
- close #88

## 주요 변경 사항 (필수)
- 이메일 중복 검증 api 추가
- 닉네임 중복 검증 api 추가

## 리뷰어 참고 사항
없음

## 추가 정보
이 PR에 data.sql 오류 수정도 함께 반영했습니다.
다만 data.sql 실행 과정에서 발생하는 오류는 GitHub Action으로는 잡기 어려워 별도로 논의가 필요할 것 같습니다.

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
