### PR TITLE
[FEATURE] 인증 API swagger 설정

### DIFF
--- a/src/main/java/ok/cherry/auth/application/AuthService.java
+++ b/src/main/java/ok/cherry/auth/application/AuthService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import ok.cherry.auth.application.dto.response.ReissueTokenResponse;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
 import ok.cherry.auth.application.dto.response.SignUpResponse;
 import ok.cherry.auth.application.dto.response.TokenResponse;
 import ok.cherry.auth.exception.AuthError;
@@ -67,7 +67,7 @@ public class AuthService {
 		authRedisRepository.saveLogoutToken(accessToken, logoutToken, expiration);
 	}
 
-	public ReissueTokenResponse reissueAccessToken(String refreshToken) {
+	public AccessTokenResponse reissueAccessToken(String refreshToken) {
 		String providerId = tokenExtractor.parseClaims(refreshToken).getSubject();
 		String restoredRefreshToken = authRedisRepository.getRefreshToken(providerId);
 

--- a/src/main/java/ok/cherry/auth/application/dto/request/SignUpRequest.java
+++ b/src/main/java/ok/cherry/auth/application/dto/request/SignUpRequest.java
@@ -1,18 +1,23 @@
 package ok.cherry.auth.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 요청 DTO")
 public record SignUpRequest(
 
+	@Schema(description = "소셜 로그인 성공 후 발급된 임시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	@NotBlank(message = "임시 토큰은 필수입니다")
 	String tempToken,
 
+	@Schema(description = "사용자 이메일 주소", example = "user@example.com")
 	@Email(message = "올바른 이메일 형식이 아닙니다")
 	@NotBlank(message = "이메일은 필수입니다")
 	String emailAddress,
 
+	@Schema(description = "닉네임 (2~10자)", example = "nickname")
 	@NotBlank(message = "닉네임은 필수입니다")
 	@Size(min = 2, max = 10)
 	String nickname

--- a/src/main/java/ok/cherry/auth/application/dto/response/AccessTokenResponse.java
+++ b/src/main/java/ok/cherry/auth/application/dto/response/AccessTokenResponse.java
@@ -1,0 +1,24 @@
+package ok.cherry.auth.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AccessToken 응답 DTO")
+public record AccessTokenResponse(
+
+	@Schema(description = "토큰 타입", example = "Bearer")
+	String tokenType,
+
+	@Schema(description = "발급된 Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "Access Token 만료 시간 (초 단위)", example = "3600")
+	Long accessTokenExpiresInSeconds
+) {
+	public static AccessTokenResponse of(TokenResponse tokenResponse) {
+		return new AccessTokenResponse(
+			tokenResponse.tokenType(),
+			tokenResponse.accessToken(),
+			tokenResponse.accessTokenExpiresInSeconds()
+		);
+	}
+}

--- a/src/main/java/ok/cherry/auth/application/dto/response/AccessTokenResponse.java
+++ b/src/main/java/ok/cherry/auth/application/dto/response/AccessTokenResponse.java
@@ -14,6 +14,7 @@ public record AccessTokenResponse(
 	@Schema(description = "Access Token 만료 시간 (초 단위)", example = "3600")
 	Long accessTokenExpiresInSeconds
 ) {
+
 	public static AccessTokenResponse of(TokenResponse tokenResponse) {
 		return new AccessTokenResponse(
 			tokenResponse.tokenType(),

--- a/src/main/java/ok/cherry/auth/application/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/ok/cherry/auth/application/dto/response/ReissueTokenResponse.java
@@ -1,9 +1,0 @@
-package ok.cherry.auth.application.dto.response;
-
-public record ReissueTokenResponse(
-
-	String tokenType,
-	String accessToken,
-	Long accessTokenExpiresInSeconds
-) {
-}

--- a/src/main/java/ok/cherry/auth/jwt/TokenGenerator.java
+++ b/src/main/java/ok/cherry/auth/jwt/TokenGenerator.java
@@ -13,7 +13,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import ok.cherry.auth.application.dto.response.ReissueTokenResponse;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
 import ok.cherry.auth.application.dto.response.TokenResponse;
 import ok.cherry.auth.exception.TokenError;
 import ok.cherry.global.exception.error.BusinessException;
@@ -69,7 +69,7 @@ public class TokenGenerator {
 	/**
 	 * AccessToken 재발급
 	 * */
-	public ReissueTokenResponse reissueAccessToken(String refreshToken, Member member) {
+	public AccessTokenResponse reissueAccessToken(String refreshToken, Member member) {
 		// 리프레시 토큰에서 사용자 정보 추출 -> 클레임 확인
 		Claims claims = tokenExtractor.parseClaims(refreshToken);
 
@@ -83,7 +83,7 @@ public class TokenGenerator {
 		long now = System.currentTimeMillis();
 		Date accessTokenExpiresIn = new Date(now + accessTokenExpiration.toMillis());
 
-		return new ReissueTokenResponse(
+		return new AccessTokenResponse(
 			BEARER_TYPE,
 			newAccessToken,
 			accessTokenExpiresIn.getTime()

--- a/src/main/java/ok/cherry/auth/presentation/AuthController.java
+++ b/src/main/java/ok/cherry/auth/presentation/AuthController.java
@@ -21,11 +21,12 @@ import ok.cherry.auth.exception.TokenError;
 import ok.cherry.auth.jwt.TokenExtractor;
 import ok.cherry.auth.util.CookieManager;
 import ok.cherry.global.exception.error.BusinessException;
+import ok.cherry.global.swagger.auth.AuthControllerDoc;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDoc {
 
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 

--- a/src/main/java/ok/cherry/auth/presentation/AuthController.java
+++ b/src/main/java/ok/cherry/auth/presentation/AuthController.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ok.cherry.auth.application.AuthService;
 import ok.cherry.auth.application.dto.request.SignUpRequest;
-import ok.cherry.auth.application.dto.response.ReissueTokenResponse;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
 import ok.cherry.auth.application.dto.response.SignUpResponse;
 import ok.cherry.auth.application.dto.response.TokenResponse;
 import ok.cherry.auth.exception.TokenError;
@@ -34,14 +34,16 @@ public class AuthController {
 	private final CookieManager cookieManager;
 
 	@PostMapping("/signup")
-	public ResponseEntity<TokenResponse> signUp(
+	public ResponseEntity<AccessTokenResponse> signUp(
 		HttpServletResponse response,
 		@RequestBody @Valid SignUpRequest request
 	) {
-		SignUpResponse signUpResponse = authService.signUp(request.emailAddress(), request.nickname(), request.tempToken());
+		SignUpResponse signUpResponse = authService.signUp(request.emailAddress(), request.nickname(),
+			request.tempToken());
 		TokenResponse tokenResponse = authService.login(signUpResponse.providerId());
 		cookieManager.setCookie(response, REFRESH_TOKEN_COOKIE_NAME, tokenResponse.refreshToken());
-		return ResponseEntity.ok(tokenResponse);
+		AccessTokenResponse accessTokenResponse = AccessTokenResponse.of(tokenResponse);
+		return ResponseEntity.ok(accessTokenResponse);
 	}
 
 	@PostMapping("/logout")
@@ -57,14 +59,14 @@ public class AuthController {
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ReissueTokenResponse> reissue(
+	public ResponseEntity<AccessTokenResponse> reissue(
 		@CookieValue(value = "refreshToken", required = false) String refreshToken
 	) {
 		if (refreshToken == null || refreshToken.isEmpty()) {
 			throw new BusinessException(TokenError.INVALID_REFRESH_TOKEN);
 		}
 
-		ReissueTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken);
+		AccessTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken);
 		return ResponseEntity.ok(tokenResponse);
 	}
 }

--- a/src/main/java/ok/cherry/global/presentation/TokenTestController.java
+++ b/src/main/java/ok/cherry/global/presentation/TokenTestController.java
@@ -7,32 +7,30 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ok.cherry.auth.application.AuthService;
 import ok.cherry.auth.application.dto.response.TokenResponse;
-import ok.cherry.auth.jwt.TokenGenerator;
-import ok.cherry.global.exception.error.BusinessException;
-import ok.cherry.global.swagger.auth.TokenTestControllerDoc;
-import ok.cherry.member.domain.Member;
-import ok.cherry.member.exception.MemberError;
-import ok.cherry.member.infrastructure.MemberRepository;
+import ok.cherry.auth.util.CookieManager;
 
 @RestController
 @Slf4j
 @RequestMapping("/test")
 @RequiredArgsConstructor
 @Profile("local")
-public class TokenTestController implements TokenTestControllerDoc {
+public class TokenTestController {
 
-	private final TokenGenerator tokenGenerator;
-	private final MemberRepository memberRepository;
+	private final AuthService authService;
+	private final CookieManager cookieManager;
 
 	@PostMapping("/token/{providerId}")
-	public ResponseEntity<TokenResponse> generateAccessTokenForTest(@PathVariable String providerId) {
-		Member member = memberRepository.findByProviderId(providerId)
-			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
-
-		TokenResponse tokenResponse = tokenGenerator.generateTokenDTO(member);
+	public ResponseEntity<TokenResponse> generateAccessTokenForTest(
+		HttpServletResponse response,
+		@PathVariable String providerId
+	) {
+		TokenResponse tokenResponse = authService.login(providerId);
+		cookieManager.setCookie(response, "refreshToken", tokenResponse.refreshToken());
 		log.info("token generated: {}", tokenResponse);
 		return ResponseEntity.ok(tokenResponse);
 	}

--- a/src/main/java/ok/cherry/global/presentation/TokenTestController.java
+++ b/src/main/java/ok/cherry/global/presentation/TokenTestController.java
@@ -1,0 +1,39 @@
+package ok.cherry.auth.presentation;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ok.cherry.auth.application.dto.response.TokenResponse;
+import ok.cherry.auth.jwt.TokenGenerator;
+import ok.cherry.global.exception.error.BusinessException;
+import ok.cherry.global.swagger.auth.TokenTestControllerDoc;
+import ok.cherry.member.domain.Member;
+import ok.cherry.member.exception.MemberError;
+import ok.cherry.member.infrastructure.MemberRepository;
+
+@RestController
+@Slf4j
+@RequestMapping("/test")
+@RequiredArgsConstructor
+@Profile("local")
+public class TokenTestController implements TokenTestControllerDoc {
+
+	private final TokenGenerator tokenGenerator;
+	private final MemberRepository memberRepository;
+
+	@PostMapping("/token/{providerId}")
+	public ResponseEntity<TokenResponse> generateAccessTokenForTest(@PathVariable String providerId) {
+		Member member = memberRepository.findByProviderId(providerId)
+			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
+
+		TokenResponse tokenResponse = tokenGenerator.generateTokenDTO(member);
+		log.info("token generated: {}", tokenResponse);
+		return ResponseEntity.ok(tokenResponse);
+	}
+}

--- a/src/main/java/ok/cherry/global/presentation/TokenTestController.java
+++ b/src/main/java/ok/cherry/global/presentation/TokenTestController.java
@@ -1,4 +1,4 @@
-package ok.cherry.auth.presentation;
+package ok.cherry.global.presentation;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/ok/cherry/global/swagger/auth/AuthControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/auth/AuthControllerDoc.java
@@ -1,0 +1,50 @@
+package ok.cherry.global.swagger.auth;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ok.cherry.auth.application.dto.request.SignUpRequest;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
+
+@Tag(name = "Authentication", description = "🔐 인증 API - 회원가입, 로그인, 로그아웃, 토큰 재발급 API")
+public interface AuthControllerDoc {
+
+	@Operation(method = "POST", summary = "회원가입", description = "소셜 로그인 성공 후 발급된 임시 토큰을 사용하여 회원가입을 진행합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "회원가입 성공",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = AccessTokenResponse.class))),
+		@ApiResponse(responseCode = "400", description = "회원가입 실패 - 유효성 검사 실패",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class))),
+		@ApiResponse(responseCode = "404", description = "회원가입 실패 - 존재하지 않는 임시 토큰",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class)))
+	})
+	ResponseEntity<AccessTokenResponse> signUp(HttpServletResponse response, SignUpRequest request);
+
+	@Operation(method = "POST", summary = "로그아웃", description = "로그아웃을 진행합니다. 서버에 저장된 Refresh Token을 삭제하고, Access Token을 블랙리스트에 추가합니다.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+		@ApiResponse(responseCode = "401", description = "로그아웃 실패 - 유효하지 않은 토큰",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class)))
+	})
+	ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response, String providerId);
+
+	@Operation(method = "POST", summary = "Access Token 재발급", description = "Refresh Token을 사용하여 새로운 Access Token을 재발급합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Access Token 재발급 성공",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = AccessTokenResponse.class))),
+		@ApiResponse(responseCode = "401", description = "Access Token 재발급 실패 - 유효하지 않은 Refresh Token",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class)))
+	})
+	ResponseEntity<AccessTokenResponse> reissue(String refreshToken);
+}

--- a/src/main/java/ok/cherry/global/swagger/auth/TokenTestControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/auth/TokenTestControllerDoc.java
@@ -1,0 +1,28 @@
+package ok.cherry.global.swagger.auth;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ok.cherry.auth.application.dto.response.TokenResponse;
+
+@Tag(name = "Dev", description = "🔧 개발 도구 - 개발용 테스트 API (개발 환경 전용)")
+public interface TokenTestControllerDoc {
+
+	@Operation(method = "POST", summary = "providerId로 토큰 발급", description = "providerId로 토큰을 발급합니다. 🚨local 환경에서만 사용 가능합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "토큰 발급 성공",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))),
+		@ApiResponse(responseCode = "404", description = "토큰 발급 실패 - 존재하지 않는 providerId",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class)))
+	})
+	ResponseEntity<TokenResponse> generateAccessTokenForTest(
+		@Parameter(description = "회원 등록시 저장된 providerId") String providerId
+	);
+}

--- a/src/test/java/ok/cherry/auth/application/AuthServiceTest.java
+++ b/src/test/java/ok/cherry/auth/application/AuthServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.jsonwebtoken.MalformedJwtException;
-import ok.cherry.auth.application.dto.response.ReissueTokenResponse;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
 import ok.cherry.auth.application.dto.response.SignUpResponse;
 import ok.cherry.auth.application.dto.response.TokenResponse;
 import ok.cherry.auth.jwt.TokenGenerator;
@@ -168,7 +168,7 @@ class AuthServiceTest {
 		TokenResponse originalTokenResponse = authService.login(providerId);
 
 		// when
-		ReissueTokenResponse reissueResponse = authService.reissueAccessToken(originalTokenResponse.refreshToken());
+		AccessTokenResponse reissueResponse = authService.reissueAccessToken(originalTokenResponse.refreshToken());
 
 		// then
 		assertThat(reissueResponse.tokenType()).isEqualTo("Bearer");

--- a/src/test/java/ok/cherry/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/ok/cherry/auth/presentation/AuthControllerTest.java
@@ -20,8 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.Cookie;
 import ok.cherry.auth.application.dto.request.SignUpRequest;
-import ok.cherry.auth.application.dto.response.ReissueTokenResponse;
-import ok.cherry.auth.application.dto.response.TokenResponse;
+import ok.cherry.auth.application.dto.response.AccessTokenResponse;
 import ok.cherry.auth.jwt.TokenGenerator;
 import ok.cherry.config.EmbeddedRedisTestConfiguration;
 import ok.cherry.global.redis.AuthRedisRepository;
@@ -37,10 +36,10 @@ class AuthControllerTest {
 
 	@Autowired
 	MockMvcTester mvcTester;
-	
+
 	@Autowired
 	ObjectMapper objectMapper;
-	
+
 	@Autowired
 	MemberRepository memberRepository;
 
@@ -56,7 +55,7 @@ class AuthControllerTest {
 		// given
 		String providerId = "12345";
 		String tempToken = tokenGenerator.generateTempToken(providerId);
-		
+
 		SignUpRequest request = new SignUpRequest(tempToken, "test@example.com", "tester");
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -71,18 +70,15 @@ class AuthControllerTest {
 		assertThat(result).hasStatusOk()
 			.bodyJson()
 			.hasPathSatisfying("$.tokenType", value -> assertThat(value).isEqualTo("Bearer"))
-			.hasPathSatisfying("$.accessToken", value -> assertThat(value).isNotNull())
-			.hasPathSatisfying("$.refreshToken", value -> assertThat(value).isNotNull());
+			.hasPathSatisfying("$.accessToken", value -> assertThat(value).isNotNull());
 
-		TokenResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), TokenResponse.class);
-		
 		Member member = memberRepository.findByProviderId(providerId).orElseThrow();
 		assertThat(member.getEmail().address()).isEqualTo("test@example.com");
 		assertThat(member.getNickname()).isEqualTo("tester");
 		assertThat(member.getProvider()).isEqualTo(Provider.KAKAO);
-		
+
 		String storedRefreshToken = authRedisRepository.getRefreshToken(providerId);
-		assertThat(storedRefreshToken).isEqualTo(response.refreshToken());
+		assertThat(storedRefreshToken).isNotNull();
 	}
 
 	@Test
@@ -109,7 +105,7 @@ class AuthControllerTest {
 	void signUpWithInvalidEmail() throws JsonProcessingException {
 		String providerId = "12345";
 		String tempToken = tokenGenerator.generateTempToken(providerId);
-		
+
 		SignUpRequest request = new SignUpRequest(tempToken, "invalid-email", "tester");
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -132,10 +128,10 @@ class AuthControllerTest {
 		String existingProviderId = "existing_kakao_123";
 		Member existingMember = Member.register(existingProviderId, Provider.KAKAO, "test@example.com", "old");
 		memberRepository.save(existingMember);
-		
+
 		String newProviderId = "new_kakao_456";
 		String tempToken = tokenGenerator.generateTempToken(newProviderId);
-		
+
 		SignUpRequest request = new SignUpRequest(tempToken, "test@example.com", "new");
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -159,7 +155,7 @@ class AuthControllerTest {
 		// given
 		String providerId = "12345";
 		String tempToken = tokenGenerator.generateTempToken(providerId);
-		
+
 		SignUpRequest signUpRequest = new SignUpRequest(tempToken, "test@example.com", "tester");
 		String signUpJson = objectMapper.writeValueAsString(signUpRequest);
 
@@ -169,13 +165,15 @@ class AuthControllerTest {
 			.content(signUpJson)
 			.exchange();
 
-		TokenResponse originalTokenResponse = objectMapper.readValue(
-			signUpResult.getResponse().getContentAsString(), TokenResponse.class);
+		AccessTokenResponse originalTokenResponse = objectMapper.readValue(
+			signUpResult.getResponse().getContentAsString(), AccessTokenResponse.class);
+
+		String refreshToken = authRedisRepository.getRefreshToken(providerId);
 
 		// when
 		MvcTestResult reissueResult = mvcTester.post()
 			.uri("/api/v1/auth/reissue")
-			.cookie(new Cookie("refreshToken", originalTokenResponse.refreshToken()))
+			.cookie(new Cookie("refreshToken", refreshToken))
 			.exchange();
 
 		// then
@@ -185,8 +183,8 @@ class AuthControllerTest {
 			.hasPathSatisfying("$.accessToken", value -> assertThat(value).isNotNull())
 			.hasPathSatisfying("$.accessTokenExpiresInSeconds", value -> assertThat(value).isNotNull());
 
-		ReissueTokenResponse reissueResponse = objectMapper.readValue(
-			reissueResult.getResponse().getContentAsString(), ReissueTokenResponse.class);
+		AccessTokenResponse reissueResponse = objectMapper.readValue(
+			reissueResult.getResponse().getContentAsString(), AccessTokenResponse.class);
 
 		assertThat(reissueResponse.accessToken()).isNotNull();
 		assertThat(reissueResponse.tokenType()).isEqualTo("Bearer");


### PR DESCRIPTION
## 관련 Issue (필수)
- close #90 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 토큰 응답에 refreshToken 제거
- 인증 API swagger 관련 코드 추가
- Local 테스트 전용 토큰 발급 컨트롤러 구현

## 리뷰어 참고 사항
로컬 환경에서 AccessToken 발급을 테스트하기 위해 TokenTestController를 /global/presentation 경로에 구현하였습니다.
해당 컨트롤러는 `@Profile("local")`이 적용되어 있어 로컬 빌드 시에만 사용 가능합니다.

## 추가 정보
### 테스트 전용 토큰 발급 API swagger 문서
<img width="1145" height="903" alt="image" src="https://github.com/user-attachments/assets/0e6d38cc-ffcc-4a14-8d55-076ddfad4314" />

### Auth API swagger 문서
<img width="1176" height="189" alt="image" src="https://github.com/user-attachments/assets/45bd7168-3b27-4b01-958a-8413717dba95" />

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
