### PR TITLE
[FEATURE] 배송 시작, 완료 기능 구현

### DIFF
--- a/src/main/java/ok/cherry/rental/domain/Rental.java
+++ b/src/main/java/ok/cherry/rental/domain/Rental.java
@@ -85,6 +85,11 @@ public class Rental {
 		return rental;
 	}
 
+	public void active() {
+		validateIsPending();
+		this.rentalStatus = RentalStatus.ACTIVE;
+	}
+
 	private static BigDecimal calculateTotalPrice(List<RentalItem> items) {
 		return items.stream()
 			.map(RentalItem::getPrice)
@@ -94,6 +99,12 @@ public class Rental {
 	private static void validateRentalNumber(String rentalNumber) {
 		if (rentalNumber == null || !rentalNumber.matches("^CH-\\d{20}$")) {
 			throw new DomainException(RentalError.INVALID_RENTAL_NUMBER);
+		}
+	}
+
+	private void validateIsPending() {
+		if (this.rentalStatus != RentalStatus.PENDING) {
+			throw new DomainException(RentalError.NOT_PENDING);
 		}
 	}
 }

--- a/src/main/java/ok/cherry/rental/exception/RentalError.java
+++ b/src/main/java/ok/cherry/rental/exception/RentalError.java
@@ -14,7 +14,9 @@ public enum RentalError implements ErrorCode {
 	RENTAL_ITEMS_NOT_EMPTY("대여 상품은 비어있을 수 없습니다", HttpStatus.BAD_REQUEST, "R_002"),
 	INVALID_RENTAL_PERIOD("대여 시작일이 종료일보다 늦을 수 없습니다", HttpStatus.BAD_REQUEST, "R_003"),
 	INVALID_RENTAL_REQUEST("유효하지 않은 대여 요청입니다", HttpStatus.BAD_REQUEST, "R_004"),
-	AMBIGUOUS_RENTAL_REQUEST("단건 대여 주문과 장바구니 주문을 동시에 요청할 수 없습니다", HttpStatus.BAD_REQUEST, "R_005");
+	AMBIGUOUS_RENTAL_REQUEST("단건 대여 주문과 장바구니 주문을 동시에 요청할 수 없습니다", HttpStatus.BAD_REQUEST, "R_005"),
+	NOT_PENDING("대여 준비 상태가 아닙니다", HttpStatus.BAD_REQUEST, "R_006"),
+	RENTAL_NOT_FOUND("대여를 찾을 수 없습니다", HttpStatus.NOT_FOUND, "R_007");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/ok/cherry/shipping/application/ShippingService.java
+++ b/src/main/java/ok/cherry/shipping/application/ShippingService.java
@@ -5,10 +5,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ok.cherry.global.exception.error.BusinessException;
 import ok.cherry.member.domain.Member;
 import ok.cherry.rental.domain.Rental;
 import ok.cherry.shipping.application.command.CreateShippingCommand;
 import ok.cherry.shipping.domain.Shipping;
+import ok.cherry.shipping.domain.type.Direction;
+import ok.cherry.shipping.exception.ShippingError;
 import ok.cherry.shipping.infrastructure.ShippingRepository;
 import ok.cherry.shipping.util.TrackingNumberGenerator;
 
@@ -38,6 +41,26 @@ public class ShippingService {
 		callExternalShippingGateway(shipping);
 
 		return shippingRepository.save(shipping);
+	}
+
+	@Transactional
+	public void startShipping(Long shippingId) {
+		Shipping shipping = shippingRepository.findById(shippingId)
+			.orElseThrow(() -> new BusinessException(ShippingError.SHIPPING_NOT_FOUND));
+		shipping.startShipping();
+		log.info("배송 시작 - 운송장 번호:{}, 배송 시작 시간: {}", shipping.getTrackingNumber(), shipping.getDetail().getStartAt());
+	}
+
+	@Transactional
+	public void completeShipping(Long shippingId) {
+		Shipping shipping = shippingRepository.findById(shippingId)
+			.orElseThrow(() -> new BusinessException(ShippingError.SHIPPING_NOT_FOUND));
+
+		if (shipping.getDirection() == Direction.OUTBOUND) {
+			shipping.getRental().active();
+		}
+		shipping.completeShipping();
+		log.info("배송 완료 - 운송장 번호:{}, 배송 완료 시간: {}", shipping.getTrackingNumber(), shipping.getDetail().getEndAt());
 	}
 
 	/**

--- a/src/main/java/ok/cherry/shipping/domain/Shipping.java
+++ b/src/main/java/ok/cherry/shipping/domain/Shipping.java
@@ -77,9 +77,35 @@ public class Shipping {
 		return shipping;
 	}
 
+	public void startShipping() {
+		validateIsPending();
+
+		this.detail.markStarted();
+		this.status = ShippingStatus.IN_DELIVERY;
+	}
+
+	public void completeShipping() {
+		validateIsInDelivery();
+
+		this.detail.markEnded();
+		this.status = ShippingStatus.DELIVERED;
+	}
+
 	private static void validateTrackingNumber(String trackingNumber) {
 		if (trackingNumber == null || !trackingNumber.matches("^\\d{20}$")) {
 			throw new DomainException(ShippingError.INVALID_TRACKING_NUMBER);
+		}
+	}
+
+	private void validateIsPending() {
+		if (this.status != ShippingStatus.PENDING) {
+			throw new DomainException(ShippingError.NOT_PENDING);
+		}
+	}
+
+	private void validateIsInDelivery() {
+		if (this.status != ShippingStatus.IN_DELIVERY) {
+			throw new DomainException(ShippingError.NOT_IN_DELIVERY);
 		}
 	}
 }

--- a/src/main/java/ok/cherry/shipping/domain/ShippingDetail.java
+++ b/src/main/java/ok/cherry/shipping/domain/ShippingDetail.java
@@ -25,4 +25,12 @@ public class ShippingDetail {
 		shippingDetail.createdAt = LocalDateTime.now();
 		return shippingDetail;
 	}
+
+	void markStarted() {
+		this.startAt = LocalDateTime.now();
+	}
+
+	void markEnded() {
+		this.endAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/ok/cherry/shipping/domain/type/Direction.java
+++ b/src/main/java/ok/cherry/shipping/domain/type/Direction.java
@@ -2,6 +2,6 @@ package ok.cherry.shipping.domain.type;
 
 public enum Direction {
 
-	INBOUND,
-	OUTBOUND
+	OUTBOUND, // 배송
+	INBOUND // 반납
 }

--- a/src/main/java/ok/cherry/shipping/exception/ShippingError.java
+++ b/src/main/java/ok/cherry/shipping/exception/ShippingError.java
@@ -10,7 +10,10 @@ import ok.cherry.global.exception.error.ErrorCode;
 @RequiredArgsConstructor
 public enum ShippingError implements ErrorCode {
 
-	INVALID_TRACKING_NUMBER("배송 번호가 유효하지 않습니다", HttpStatus.BAD_REQUEST, "S_001");
+	INVALID_TRACKING_NUMBER("배송 번호가 유효하지 않습니다", HttpStatus.BAD_REQUEST, "S_001"),
+	SHIPPING_NOT_FOUND("배송을 찾을 수 없습니다", HttpStatus.NOT_FOUND, "S_002"),
+	NOT_PENDING("배송 준비 상태가 아닙니다", HttpStatus.BAD_REQUEST, "S_003"),
+	NOT_IN_DELIVERY("배송 중이 아닙니다", HttpStatus.BAD_REQUEST, "S_004");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/test/java/ok/cherry/rental/domain/RentalTest.java
+++ b/src/test/java/ok/cherry/rental/domain/RentalTest.java
@@ -1,6 +1,7 @@
 package ok.cherry.rental.domain;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ import ok.cherry.member.MemberBuilder;
 import ok.cherry.member.domain.Member;
 import ok.cherry.rental.RentalBuilder;
 import ok.cherry.rental.RentalItemBuilder;
+import ok.cherry.rental.domain.status.RentalStatus;
 import ok.cherry.rental.exception.RentalError;
 
 class RentalTest {
@@ -79,5 +81,31 @@ class RentalTest {
 		assertThatThrownBy(() -> RentalBuilder.builder().withRentalNumber(wrongRentalNumber).build())
 			.isInstanceOf(DomainException.class)
 			.hasMessage(RentalError.INVALID_RENTAL_NUMBER.getMessage());
+	}
+
+	@Test
+	@DisplayName("대여 활성화 시 대여 상태가 ACTIVE로 변경된다")
+	void active_success() {
+		// given
+		Rental rental = RentalBuilder.create();
+
+		// when
+		rental.active();
+
+		// then
+		assertThat(rental.getRentalStatus()).isEqualTo(RentalStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("대여 활성화 시 대여 상태가 PENDING이 아니면 예외가 발생한다")
+	void active_notPending() {
+		// given
+		Rental rental = RentalBuilder.create();
+		rental.active();
+
+		// when & then
+		assertThatThrownBy(() -> rental.active())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(RentalError.NOT_PENDING.getMessage());
 	}
 }

--- a/src/test/java/ok/cherry/shipping/application/ShippingServiceTest.java
+++ b/src/test/java/ok/cherry/shipping/application/ShippingServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
+import ok.cherry.global.exception.error.DomainException;
 import ok.cherry.member.MemberBuilder;
 import ok.cherry.member.domain.Member;
 import ok.cherry.member.infrastructure.MemberRepository;
@@ -17,12 +18,15 @@ import ok.cherry.product.domain.Product;
 import ok.cherry.product.infrastructure.ProductRepository;
 import ok.cherry.rental.RentalBuilder;
 import ok.cherry.rental.domain.Rental;
+import ok.cherry.rental.domain.status.RentalStatus;
 import ok.cherry.rental.infrastructure.RentalRepository;
+import ok.cherry.shipping.ShippingBuilder;
 import ok.cherry.shipping.application.command.CreateShippingCommand;
 import ok.cherry.shipping.domain.Address;
 import ok.cherry.shipping.domain.Shipping;
 import ok.cherry.shipping.domain.status.ShippingStatus;
 import ok.cherry.shipping.domain.type.Direction;
+import ok.cherry.shipping.exception.ShippingError;
 import ok.cherry.shipping.infrastructure.ShippingRepository;
 
 @SpringBootTest
@@ -204,6 +208,149 @@ class ShippingServiceTest {
 		assertThat(shipping1.getTrackingNumber()).isNotEqualTo(shipping2.getTrackingNumber());
 		assertThat(shipping1.getTrackingNumber()).matches("^\\d{20}$");
 		assertThat(shipping2.getTrackingNumber()).matches("^\\d{20}$");
+	}
+
+	@Test
+	@DisplayName("배송 시작 시 배송 상태가 변경되고 배송 시작 시간이 생성된다")
+	void startShipping_success() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(
+			RentalBuilder.builder()
+				.withProduct(product)
+				.withMember(member)
+				.build()
+		);
+		Shipping shipping = shippingRepository.save(
+			ShippingBuilder.builder()
+				.withRental(rental)
+				.build()
+		);
+		flushAndClear();
+
+		// when
+		shippingService.startShipping(shipping.getId());
+
+		// then
+		Shipping savedShipping = shippingRepository.findById(shipping.getId()).orElseThrow();
+		assertThat(savedShipping.getStatus()).isEqualTo(ShippingStatus.IN_DELIVERY);
+		assertThat(savedShipping.getDetail().getStartAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("배송 대기 중 상태가 아닐 때 배송 시작을 하는 경우 예외가 발생한다")
+	void startShipping_notPending() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(
+			RentalBuilder.builder()
+				.withProduct(product)
+				.withMember(member)
+				.build()
+		);
+		Shipping shipping = shippingRepository.save(
+			ShippingBuilder.builder()
+				.withRental(rental)
+				.build()
+		);
+		shipping.startShipping();
+		flushAndClear();
+
+		// when & then
+		Shipping savedShipping = shippingRepository.findById(shipping.getId()).orElseThrow();
+		assertThatThrownBy(() -> shippingService.startShipping(savedShipping.getId()))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(ShippingError.NOT_PENDING.getMessage());
+	}
+
+	@Test
+	@DisplayName("배송 완료 시 배송 상태가 변경되고 배송 완료 시간이 생성된다")
+	void completeShipping_success() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(
+			RentalBuilder.builder()
+				.withProduct(product)
+				.withMember(member)
+				.build()
+		);
+		Shipping shipping = shippingRepository.save(
+			ShippingBuilder.builder()
+				.withRental(rental)
+				.build()
+		);
+		shipping.startShipping();
+		flushAndClear();
+
+		// when
+		Shipping savedShipping = shippingRepository.findById(shipping.getId()).orElseThrow();
+		shippingService.completeShipping(savedShipping.getId());
+
+		// then
+		assertThat(savedShipping.getStatus()).isEqualTo(ShippingStatus.DELIVERED);
+		assertThat(savedShipping.getDetail().getEndAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("배송 완료 시 배송 방향이 Outbound인 경우 관련된 대여의 상태가 활성화 된다")
+	void completeShipping_rentalStatusActive() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(
+			RentalBuilder.builder()
+				.withProduct(product)
+				.withMember(member)
+				.build()
+		);
+		Shipping shipping = shippingRepository.save(
+			ShippingBuilder.builder()
+				.withRental(rental)
+				.withDirection(Direction.OUTBOUND)
+				.build()
+		);
+		shipping.startShipping();
+		flushAndClear();
+
+		// when
+		shippingService.completeShipping(shipping.getId());
+
+		// then
+		Shipping savedShipping = shippingRepository.findById(shipping.getId()).orElseThrow();
+		assertThat(savedShipping.getStatus()).isEqualTo(ShippingStatus.DELIVERED);
+		assertThat(savedShipping.getDetail().getEndAt()).isNotNull();
+		assertThat(savedShipping.getRental().getRentalStatus()).isEqualTo(RentalStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("배송 중 상태가 아닐 때 배송 완료를 하는 경우 예외가 발생한다 ")
+	void completeShipping_notInDelivery() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(
+			RentalBuilder.builder()
+				.withProduct(product)
+				.withMember(member)
+				.build()
+		);
+		Shipping shipping = shippingRepository.save(
+			ShippingBuilder.builder()
+				.withRental(rental)
+				.build()
+		);
+		shipping.startShipping();
+		shipping.completeShipping();
+		flushAndClear();
+
+		// when & then
+		Shipping savedShipping = shippingRepository.findById(shipping.getId()).orElseThrow();
+		assertThatThrownBy(() -> shippingService.completeShipping(savedShipping.getId()))
+			.isInstanceOf(DomainException.class)
+			.hasMessage(ShippingError.NOT_IN_DELIVERY.getMessage());
 	}
 
 	private void flushAndClear() {

--- a/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
+++ b/src/test/java/ok/cherry/shipping/domain/ShippingTest.java
@@ -1,6 +1,7 @@
 package ok.cherry.shipping.domain;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -105,5 +106,61 @@ class ShippingTest {
 		assertThatThrownBy(() -> ShippingBuilder.builder().withTrackingNumber(trackingNumber).build())
 			.isInstanceOf(DomainException.class)
 			.hasMessage(ShippingError.INVALID_TRACKING_NUMBER.getMessage());
+	}
+
+	@Test
+	@DisplayName("배송 시작 시 배송 상태가 변경되고 배송 시작 시간이 생성된다")
+	void startShipping_success() {
+		// given
+		Shipping shipping = ShippingBuilder.create();
+
+		// when
+		shipping.startShipping();
+
+		// then
+		assertThat(shipping.getStatus()).isEqualTo(ShippingStatus.IN_DELIVERY);
+		assertThat(shipping.getDetail().getStartAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("배송 대기 중 상태가 아닐 때 배송 시작을 하는 경우 예외가 발생한다")
+	void startShipping_notPending() {
+		// given
+		Shipping shipping = ShippingBuilder.create();
+		shipping.startShipping();
+
+		// when & then
+		assertThatThrownBy(() -> shipping.startShipping())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(ShippingError.NOT_PENDING.getMessage());
+	}
+
+	@Test
+	@DisplayName("배송 완료 시 배송 상태가 변경되고 배송 완료 시간이 생성된다")
+	void completeShipping_success() {
+		// given
+		Shipping shipping = ShippingBuilder.create();
+		shipping.startShipping();
+
+		// when
+		shipping.completeShipping();
+
+		// then
+		assertThat(shipping.getStatus()).isEqualTo(ShippingStatus.DELIVERED);
+		assertThat(shipping.getDetail().getEndAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("배송 중 상태가 아닐 때 배송 완료를 하는 경우 예외가 발생한다 ")
+	void completeShipping_notInDelivery() {
+		// given
+		Shipping shipping = ShippingBuilder.create();
+		shipping.startShipping();
+		shipping.completeShipping();
+
+		// when & then
+		assertThatThrownBy(() -> shipping.completeShipping())
+			.isInstanceOf(DomainException.class)
+			.hasMessage(ShippingError.NOT_IN_DELIVERY.getMessage());
 	}
 }


### PR DESCRIPTION
## 관련 Issue (필수)
- close #103

## 주요 변경 사항 (필수)
- 배송 시작 로직 구현
- 배송 완료 로직 구현

## 리뷰어 참고 사항
배송 방향은 `OUTBOUND`(cherry → 사용자)와 `INBOUND`(사용자 → cherry)로 배송 완료 시 `OUTBOUND`일 경우 관련된 `Rental` 상태가 `ACTIVE`로 변경됩니다.

제가 처음에 잘못 생각해서 ShippingApplicationService에서 RentalService를 사용하도록 로직을 구현했습니다...
해당 pr에서 다시 작성해서 force push 하겠습니다!

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
