### PR TITLE
[FEATURE] 대여 상세 조회 기능 구현

### DIFF
--- a/http/rental.http
+++ b/http/rental.http
@@ -81,7 +81,7 @@ Content-Type: application/json
 # POST /api/v1/rentals
 # productId와 cartIds가 모두 있는 애매한 요청
 POST http://localhost:8080/api/v1/rentals
-Authorization: Bearer {{accessToken_12345}}
+Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
 {
@@ -104,3 +104,11 @@ Content-Type: application/json
   },
   "paymentMethod": "KAKAO_PAY"
 }
+
+### 상품 단건 조회
+GET http://localhost:8080/api/v1/rentals/1
+Authorization: Bearer {{accessToken}}
+
+### 상품 목록 조회
+GET http://localhost:8080/api/v1/rentals
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/ok/cherry/global/swagger/auth/AuthControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/auth/AuthControllerDoc.java
@@ -39,7 +39,9 @@ public interface AuthControllerDoc {
 	})
 	ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response, String providerId);
 
-	@Operation(method = "POST", summary = "Access Token 재발급", description = "Refresh Token을 사용하여 새로운 Access Token을 재발급합니다.")
+	@Operation(method = "POST", summary = "Access Token 재발급", description = "Refresh Token을 사용하여 새로운 Access Token을 재발급합니다.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Access Token 재발급 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = AccessTokenResponse.class))),

--- a/src/main/java/ok/cherry/global/swagger/cart/CartControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/cart/CartControllerDoc.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import ok.cherry.cart.application.dto.request.CartCreateRequest;
 import ok.cherry.cart.application.dto.request.CartDeleteRequest;
@@ -18,7 +19,9 @@ import ok.cherry.cart.application.dto.response.CartGetResponse;
 @Tag(name = "Carts", description = "🛒 장바구니 API - 장바구니 조회, 관리 API")
 public interface CartControllerDoc {
 
-	@Operation(method = "POST", summary = "장바구니 상품 추가", description = "장바구니에 상품을 추가합니다")
+	@Operation(method = "POST", summary = "장바구니 상품 추가", description = "장바구니에 상품을 추가합니다",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "장바구니 상품 등록 성공",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = CartCreateResponse.class))),
@@ -31,7 +34,9 @@ public interface CartControllerDoc {
 	})
 	ResponseEntity<CartCreateResponse> createCart(CartCreateRequest request, String providerId);
 
-	@Operation(method = "DELETE", summary = "장바구니 상품 삭제", description = "장바구니에 담긴 상품을 삭제합니다")
+	@Operation(method = "DELETE", summary = "장바구니 상품 삭제", description = "장바구니에 담긴 상품을 삭제합니다",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "장바구니 상품 삭제 성공"),
 		@ApiResponse(responseCode = "401", description = "장바구니 상품 삭제 실패 - 요청에 대한 장바구니 상품 소유자가 일치하지 않음",
@@ -43,7 +48,9 @@ public interface CartControllerDoc {
 	})
 	ResponseEntity<Void> deleteCart(CartDeleteRequest request, String providerId);
 
-	@Operation(method = "GET", summary = "장바구니 상품 조회", description = "장바구니에 담긴 상품을 조회합니다")
+	@Operation(method = "GET", summary = "장바구니 상품 조회", description = "장바구니에 담긴 상품을 조회합니다",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200",
 			description = "장바구니 상품 조회 성공: "

--- a/src/main/java/ok/cherry/global/swagger/payment/PaymentControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/payment/PaymentControllerDoc.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import ok.cherry.payment.application.dto.response.PaymentResponse;
 
@@ -16,7 +17,9 @@ import ok.cherry.payment.application.dto.response.PaymentResponse;
 public interface PaymentControllerDoc {
 
 	@Operation(method = "GET", summary = "결제 정보 조회",
-		description = "특정 결제 ID에 해당하는 결제 정보와 결제 아이템들을 조회합니다.")
+		description = "특정 결제 ID에 해당하는 결제 정보와 결제 아이템들을 조회합니다.",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "결제 정보 조회 성공",
 			content = @Content(mediaType = "application/json",
@@ -32,9 +35,7 @@ public interface PaymentControllerDoc {
 				schema = @Schema(implementation = ProblemDetail.class)))
 	})
 	ResponseEntity<PaymentResponse> getPayment(
-		@Parameter(description = "조회할 결제 ID", example = "1", required = true)
-		Long paymentId,
-		@Parameter(hidden = true)
-		String providerId
+		@Parameter(description = "조회할 결제 ID", example = "1", required = true) Long paymentId,
+		@Parameter(hidden = true) String providerId
 	);
 }

--- a/src/main/java/ok/cherry/global/swagger/rental/RentalControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/rental/RentalControllerDoc.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import ok.cherry.rental.application.request.PlaceRentalOrderRequest;
 import ok.cherry.rental.application.response.PlaceRentalOrderResponse;
 import ok.cherry.rental.application.response.RentalGetResponse;
+import ok.cherry.rental.application.response.RentalInfoResponse;
 
 @Tag(name = "Rentals")
 public interface RentalControllerDoc {
@@ -31,16 +32,36 @@ public interface RentalControllerDoc {
 		@Parameter(hidden = true) String providerId
 	);
 
+	@Operation(method = "GET", summary = "사용자 이용내역(대여) 상세 조회", description = "사용자의 이용내역을 상세 조회합니다")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200",
+			description = "대여 상세 조회 성공",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = RentalInfoResponse.class))),
+		@ApiResponse(responseCode = "401",
+			description = "인증되지 않은 사용자",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class))),
+		@ApiResponse(responseCode = "403",
+			description = "접근 권한이 없는 대여 정보",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class))),
+		@ApiResponse(responseCode = "404",
+			description = "존재하지 않는 대여 정보",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetail.class)))
+	})
+	ResponseEntity<RentalInfoResponse> getRental(
+		@Parameter(description = "조회할 대여 Id") Long rentalId,
+		@Parameter(hidden = true) String providerId
+	);
+
 	@Operation(
 		method = "POST",
 		summary = "대여 주문 생성",
 		description = """
 			새로운 대여 주문을 생성합니다.
-						
+					
 			**지원하는 결제 방식:**
 			- **직접 결제**: productId + color로 단일 상품 대여
 			- **장바구니 결제**: cartIds로 장바구니에 담긴 여러 상품 대여
-						
+					
 			**처리 플로우:**
 			1. 대여 생성 (RentalService)
 			2. 결제 처리 (PaymentService) 

--- a/src/main/java/ok/cherry/global/swagger/rental/RentalControllerDoc.java
+++ b/src/main/java/ok/cherry/global/swagger/rental/RentalControllerDoc.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import ok.cherry.rental.application.request.PlaceRentalOrderRequest;
 import ok.cherry.rental.application.response.PlaceRentalOrderResponse;
@@ -18,7 +19,9 @@ import ok.cherry.rental.application.response.RentalInfoResponse;
 @Tag(name = "Rentals")
 public interface RentalControllerDoc {
 
-	@Operation(method = "GET", summary = "사용자 이용내역(대여) 목록 조회", description = "사용자의 이용내역 목록을 조회하며, 커서 기반 페이지네이션을 사용합니다")
+	@Operation(method = "GET", summary = "사용자 이용내역(대여) 목록 조회", description = "사용자의 이용내역 목록을 조회하며, 커서 기반 페이지네이션을 사용합니다",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200",
 			description = "대여 목록 조회 성공: "
@@ -29,10 +32,12 @@ public interface RentalControllerDoc {
 	ResponseEntity<RentalGetResponse> getRentals(
 		@Parameter(description = "페이지네이션 커서. 이전 응답의 `lastRentalId` 값을 전달하면 다음 페이지를 조회합니다") Long lastRentalId,
 		@Parameter(description = "한 페이지에 보여줄 상품 개수", schema = @Schema(type = "integer", defaultValue = "2")) int limit,
-		@Parameter(hidden = true) String providerId
+		@Parameter String providerId
 	);
 
-	@Operation(method = "GET", summary = "사용자 이용내역(대여) 상세 조회", description = "사용자의 이용내역을 상세 조회합니다")
+	@Operation(method = "GET", summary = "사용자 이용내역(대여) 상세 조회", description = "사용자의 이용내역을 상세 조회합니다",
+		security = {@SecurityRequirement(name = "JWT")}
+	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200",
 			description = "대여 상세 조회 성공",
@@ -49,7 +54,7 @@ public interface RentalControllerDoc {
 	})
 	ResponseEntity<RentalInfoResponse> getRental(
 		@Parameter(description = "조회할 대여 Id") Long rentalId,
-		@Parameter(hidden = true) String providerId
+		@Parameter String providerId
 	);
 
 	@Operation(
@@ -67,7 +72,8 @@ public interface RentalControllerDoc {
 			2. 결제 처리 (PaymentService) 
 			3. 배송 생성 (ShippingService)
 			4. 장바구니 정리 (장바구니 결제인 경우)
-			"""
+			""",
+		security = {@SecurityRequirement(name = "JWT")}
 	)
 	@ApiResponses(value = {
 		@ApiResponse(
@@ -128,6 +134,6 @@ public interface RentalControllerDoc {
 	})
 	ResponseEntity<PlaceRentalOrderResponse> placeRentalOrder(
 		PlaceRentalOrderRequest request,
-		@Parameter(hidden = true) String providerId
+		@Parameter String providerId
 	);
 }

--- a/src/main/java/ok/cherry/rental/application/RentalService.java
+++ b/src/main/java/ok/cherry/rental/application/RentalService.java
@@ -47,7 +47,7 @@ public class RentalService {
 	@Transactional(readOnly = true)
 	public RentalGetResponse getRentals(Long lastRentalId, int limit, String providerId) {
 		Pageable pageable = PageRequest.of(0, limit + 1);
-		
+
 		List<Rental> rentals = rentalRepository.findRentalsWithCursorPagination(
 			providerId, lastRentalId, pageable
 		);
@@ -77,9 +77,24 @@ public class RentalService {
 	}
 
 	@Transactional(readOnly = true)
+	public Rental getRental(Long rentalId, String providerId) {
+		Rental rental = rentalRepository.findByIdWithDetails(rentalId)
+			.orElseThrow(() -> new BusinessException(RentalError.RENTAL_NOT_FOUND));
+
+		validateOwnership(providerId, rental);
+		return rental;
+	}
+
+	@Transactional(readOnly = true)
 	public Rental findRentalById(Long rentalId) {
 		return rentalRepository.findById(rentalId)
 			.orElseThrow(() -> new BusinessException(RentalError.RENTAL_NOT_FOUND));
+	}
+
+	private void validateOwnership(String providerId, Rental rental) {
+		if (!rental.getMember().getProviderId().equals(providerId)) {
+			throw new BusinessException(RentalError.FORBIDDEN_ACCESS);
+		}
 	}
 
 	private static void validateRentalItems(List<RentalItem> items) {

--- a/src/main/java/ok/cherry/rental/exception/RentalError.java
+++ b/src/main/java/ok/cherry/rental/exception/RentalError.java
@@ -20,7 +20,8 @@ public enum RentalError implements ErrorCode {
 	NOT_ACTIVE("대여 중 상태가 아닙니다", HttpStatus.BAD_REQUEST, "R_008"),
 	NOT_IN_RETURN("반납 중 상태가 아닙니다", HttpStatus.BAD_REQUEST, "R_009"),
 	NOT_COMPLETED("대여 완료 상태가 아닙니다", HttpStatus.BAD_REQUEST, "R_010"),
-	NOT_REVIEW_STATUS_AVAILABLE("리뷰를 작성할 수 없습니다", HttpStatus.BAD_REQUEST, "R_011");
+	NOT_REVIEW_STATUS_AVAILABLE("리뷰를 작성할 수 없습니다", HttpStatus.BAD_REQUEST, "R_011"),
+	FORBIDDEN_ACCESS("접근 권한이 없습니다", HttpStatus.FORBIDDEN, "R_012");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/ok/cherry/rental/infrastructure/RentalRepository.java
+++ b/src/main/java/ok/cherry/rental/infrastructure/RentalRepository.java
@@ -2,6 +2,7 @@ package ok.cherry.rental.infrastructure;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,6 +28,13 @@ public interface RentalRepository extends JpaRepository<Rental, Long> {
 		@Param("lastRentalId") Long lastRentalId,
 		Pageable pageable
 	);
+
+	@Query("SELECT r FROM Rental r " +
+		"LEFT JOIN FETCH r.member " +
+		"LEFT JOIN FETCH r.rentalItems ri " +
+		"LEFT JOIN FETCH ri.product " +
+		"WHERE r.id = :rentalId")
+	Optional<Rental> findByIdWithDetails(@Param("rentalId") Long rentalId);
 
 	List<Rental> findByRentalStatusAndDetail_EndAtBefore(RentalStatus rentalStatus, LocalDate today);
 }

--- a/src/main/java/ok/cherry/rental/presentation/RentalController.java
+++ b/src/main/java/ok/cherry/rental/presentation/RentalController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,8 @@ import ok.cherry.rental.application.RentalService;
 import ok.cherry.rental.application.request.PlaceRentalOrderRequest;
 import ok.cherry.rental.application.response.PlaceRentalOrderResponse;
 import ok.cherry.rental.application.response.RentalGetResponse;
+import ok.cherry.rental.application.response.RentalInfoResponse;
+import ok.cherry.rental.domain.Rental;
 
 @RestController
 @RequestMapping("/api/v1/rentals")
@@ -25,6 +28,16 @@ public class RentalController implements RentalControllerDoc {
 
 	private final RentalService rentalService;
 	private final RentalApplicationService rentalApplicationService;
+
+	@GetMapping("{rentalId}")
+	public ResponseEntity<RentalInfoResponse> getRental(
+		@PathVariable Long rentalId,
+		@AuthenticationPrincipal String providerId
+	) {
+		Rental rental = rentalService.getRental(rentalId, providerId);
+		RentalInfoResponse response = RentalInfoResponse.from(rental);
+		return ResponseEntity.ok(response);
+	}
 
 	@GetMapping
 	public ResponseEntity<RentalGetResponse> getRentals(

--- a/src/test/java/ok/cherry/rental/application/RentalServiceTest.java
+++ b/src/test/java/ok/cherry/rental/application/RentalServiceTest.java
@@ -248,6 +248,61 @@ class RentalServiceTest {
 			.hasMessage(RentalError.NOT_COMPLETED.getMessage());
 	}
 
+	@Test
+	@DisplayName("자신의 대여 기록을 상세 조회하는데 성공한다")
+	void getRental_success() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(RentalBuilder.builder()
+			.withMember(member)
+			.withRentalItems(List.of(RentalItemBuilder.builder().withProduct(product).build()))
+			.build());
+
+		// when
+		Rental result = rentalService.getRental(rental.getId(), member.getProviderId());
+
+		// then
+		assertThat(result.getId()).isEqualTo(rental.getId());
+		assertThat(result.getMember().getId()).isEqualTo(member.getId());
+	}
+
+	@Test
+	@DisplayName("다른 사람의 대여 기록을 조회하면 예외가 발생한다")
+	void getRental_forbidden() {
+		// given
+		Member owner = memberRepository.save(MemberBuilder.create());
+		Member other = memberRepository.save(MemberBuilder.builder()
+			.withProviderId("other")
+			.withEmail("other@test.com")
+			.withNickname("other")
+			.build()
+		);
+		Product product = productRepository.save(ProductBuilder.create());
+		Rental rental = rentalRepository.save(RentalBuilder.builder()
+			.withMember(owner)
+			.withRentalItems(List.of(RentalItemBuilder.builder().withProduct(product).build()))
+			.build());
+
+		// when & then
+		assertThatThrownBy(() -> rentalService.getRental(rental.getId(), other.getProviderId()))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage(RentalError.FORBIDDEN_ACCESS.getMessage());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 대여 기록을 조회하면 예외가 발생한다")
+	void getRental_notFound() {
+		// given
+		Member member = memberRepository.save(MemberBuilder.create());
+		long notExistRentalId = 999L;
+
+		// when & then
+		assertThatThrownBy(() -> rentalService.getRental(notExistRentalId, member.getProviderId()))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage(RentalError.RENTAL_NOT_FOUND.getMessage());
+	}
+
 	private void saveRentals(Member savedMember, Product product) {
 		rentalRepository.saveAll(List.of(
 			RentalBuilder.builder()


### PR DESCRIPTION
## 관련 Issue (필수)
- close #107 

## 주요 변경 사항 (필수)
- 대여 상세 조회 로직 구현
- swagger에 JWT 인증 필드 추가

## 리뷰어 참고 사항
<img width="652" height="297" alt="image" src="https://github.com/user-attachments/assets/04f4fb7a-3dc0-468b-909b-839f2b99a359" />

Swagger 전반에 providerId 기반 JWT 인증 필드가 누락되어 있어 관련 컨트롤러들에 모두 추가하였습니다.
한 번 accessToken을 입력하면 Swagger가 이후 다른 API 호출 시마다 자동으로 JWT를 주입해줍니다.

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
