### PR TITLE
[FEATURE] 회원 탈퇴 시 기존 회원 providerId 데이터 포맷

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -29,3 +29,7 @@ Content-Type: application/json
 {
   "nickname": "tester1"
 }
+
+### 회원 탈퇴
+DELETE http://localhost:8080/api/v1/members
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/ok/cherry/member/domain/Member.java
+++ b/src/main/java/ok/cherry/member/domain/Member.java
@@ -34,7 +34,7 @@ public class Member {
 	@Column(nullable = false)
 	private Provider provider;
 
-	@Column(nullable = false, unique = true, updatable = false)
+	@Column(nullable = false, unique = true)
 	private String providerId;
 
 	@Embedded
@@ -103,5 +103,6 @@ public class Member {
 
 		this.email = new Email(localPart + formattedTime + domainPart);
 		this.nickname = this.nickname + formattedTime;
+		this.providerId = this.providerId + formattedTime;
 	}
 }

--- a/src/test/java/ok/cherry/member/application/MemberApplicationServiceTest.java
+++ b/src/test/java/ok/cherry/member/application/MemberApplicationServiceTest.java
@@ -51,6 +51,7 @@ class MemberApplicationServiceTest {
 
 		String originalEmail = savedMember.getEmail().address();
 		String originalNickname = savedMember.getNickname();
+		String originalProviderId = savedMember.getProviderId();
 
 		TokenResponse tokenResponse = authService.login(savedMember.getProviderId());
 		String accessToken = tokenResponse.accessToken();
@@ -63,7 +64,7 @@ class MemberApplicationServiceTest {
 			.orElseThrow();
 		assertThat(deactivatedMember.getMemberStatus()).isEqualTo(MemberStatus.DEACTIVATED);
 
-		// 이메일과 닉네임에 탈퇴일시가 포맷되어 저장되었는지 검증
+		// 이메일, 닉네임, providerId에 탈퇴일시가 포맷되어 저장되었는지 검증
 		LocalDateTime deactivatedAt = deactivatedMember.getDetail().getDeactivatedAt();
 		String formattedTime = deactivatedAt.format(DEACTIVATION_DATE_FORMATTER);
 
@@ -73,6 +74,7 @@ class MemberApplicationServiceTest {
 
 		assertThat(deactivatedMember.getEmail().address()).isEqualTo(localPart + formattedTime + domainPart);
 		assertThat(deactivatedMember.getNickname()).isEqualTo(originalNickname + formattedTime);
+		assertThat(deactivatedMember.getProviderId()).isEqualTo(originalProviderId + formattedTime);
 
 		// 로그아웃 되었는지 검증
 		assertThat(authRedisRepository.getRefreshToken(savedMember.getProviderId())).isNull();


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #156 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 회원 탈퇴 시 providerId 에 탈퇴일시를 포함하여 포맷할 수 있도록 변경
- Member providerId 필드 @Column 속성에 updatable 속성 제거

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
### 탈퇴 시 DB에 저장된 providerId
<img width="634" height="68" alt="스크린샷 2025-09-11 오후 6 19 10" src="https://github.com/user-attachments/assets/20990340-6f86-46a5-9875-07d8203826e6" />


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.
